### PR TITLE
Add, update and delete TEI documents

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -353,6 +353,50 @@ paths:
             application/xml:
               schema:
                 type: string
+    put:
+      summary: Add new or update existing TEI document
+      description: |
+        When sending a PUT request to a new play URI, the request body is stored
+        in the database as a new document accessible under that URI. If the URI
+        already exists the corresponding TEI document is updated with the
+        request body.
+
+        The `playname` parameter of a new URI must consist of lower case ASCII
+        characters, digits and/or dashes only.
+      operationId: play-tei-put
+      tags: [admin]
+      parameters:
+        - name: corpusname
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: playname
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: "[a-z0-9]+([-a-z0-9]?[a-z0-9])?"
+      requestBody:
+        description: TEI document
+        content:
+          application/xml:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: TEI document has been stored
+          content:
+            application/xml:
+              schema:
+                type: string
+        '400':
+          description: >-
+            The request body is not a valid TEI document or the `playname` is
+            invalid.
+        '404':
+          description: >-
+            There is no corpus with the given `corpusname`.
 
   /corpora/{corpusname}/play/{playname}/rdf:
     get:

--- a/api.yaml
+++ b/api.yaml
@@ -329,6 +329,26 @@ paths:
             application/json:
               schema:
                 type: object
+    delete:
+      summary: Remove a single play from the corpus
+      operationId: play-delete
+      tags: [admin]
+      parameters:
+        - name: corpusname
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: playname
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Play has been removed
+        '404':
+          description: No such play under this URI
 
   /corpora/{corpusname}/play/{playname}/tei:
     get:

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -473,6 +473,31 @@ function api:play-info($corpusname, $playname) {
 };
 
 declare
+  %rest:DELETE
+  %rest:path("/corpora/{$corpusname}/play/{$playname}")
+  %rest:header-param("Authorization", "{$auth}")
+  %output:method("json")
+function api:play-delete($corpusname, $playname, $data, $auth) {
+  if (not($auth)) then
+    <rest:response>
+      <http:response status="401"/>
+    </rest:response>
+  else
+
+  let $doc := dutil:get-doc($corpusname, $playname)
+
+  return
+    if (not($doc)) then
+      <rest:response>
+        <http:response status="404"/>
+      </rest:response>
+    else
+      let $filename := $playname || ".xml"
+      let $collection := $config:data-root || "/" || $corpusname
+      return (xmldb:remove($collection, $filename))
+};
+
+declare
   %rest:GET
   %rest:path("/corpora/{$corpusname}/play/{$playname}/tei")
   %rest:produces("application/xml", "text/xml")

--- a/modules/trigger.xqm
+++ b/modules/trigger.xqm
@@ -27,7 +27,7 @@ declare function trigger:after-update-document($url as xs:anyURI) {
   )
 };
 
-declare function trigger:after-delete-document($url as xs:anyURI) {
+declare function trigger:before-delete-document($url as xs:anyURI) {
   if (doc($url)/tei:TEI) then
     let $paths := dutil:filepaths($url)
     return try {


### PR DESCRIPTION
This PR implements the `PUT` and `DELETE` methods allowing to add and update as well as remove TEI documents from a corpus.

resolves #45