### PR TITLE
Integrate openapi4restxq

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -69,6 +69,11 @@
       dest="${dependencies.dir}/sparql-latest.xar"
       skipexisting="true"
       ignoreerrors="true"/>
+    <get
+      src="https://ci.de.dariah.eu/exist-repo/public/openapi-1.2.0.xar"
+      dest="${dependencies.dir}/openapi-1.2.0.xar"
+      skipexisting="true"
+      ignoreerrors="true"/>
   </target>
 
   <target

--- a/build.xml
+++ b/build.xml
@@ -70,8 +70,8 @@
       skipexisting="true"
       ignoreerrors="true"/>
     <get
-      src="https://ci.de.dariah.eu/exist-repo/public/openapi-1.2.0.xar"
-      dest="${dependencies.dir}/openapi-1.2.0.xar"
+      src="https://ci.de.dariah.eu/exist-repo/public/openapi-1.5.0.xar"
+      dest="${dependencies.dir}/openapi-1.5.0.xar"
       skipexisting="true"
       ignoreerrors="true"/>
   </target>

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -7,6 +7,7 @@ import module namespace dutil = "http://dracor.org/ns/exist/util" at "util.xqm";
 import module namespace load = "http://dracor.org/ns/exist/load" at "load.xqm";
 import module namespace sparql = "http://exist-db.org/xquery/sparql"
   at "java:org.exist.xquery.modules.rdf.SparqlModule";
+import module namespace openapi = "https://lab.sub.uni-goettingen.de/restxqopenapi";
 
 declare namespace rest = "http://exquery.org/ns/restxq";
 declare namespace http = "http://expath.org/ns/http-client";
@@ -45,6 +46,21 @@ declare
   %output:method("json")
 function api:darcor() {
   local:get-info()
+};
+
+(:~
+ : OpenAPI info
+ :
+ : @result JSON object
+ :)
+declare
+  %rest:GET
+  %rest:path("/openapi")
+  %rest:produces("application/json")
+  %output:media-type("application/json")
+  %output:method("json")
+function api:openapi() {
+  openapi:main("/db/apps/dracor")
 };
 
 declare

--- a/modules/webhook.xqm
+++ b/modules/webhook.xqm
@@ -88,6 +88,20 @@ declare function local:handle-delivery (
   return $result
 };
 
+(:~
+ : GitHub Webhook
+ :
+ : Endpoint accepting POST requests from Github (see
+ : https://developer.github.com/webhooks/). We currently only handle push
+ : events on the master branch.
+ :
+ : @param $data JSON payload
+ : @param $agent User agent string
+ : @param $event GitHub event
+ : @param $delivery Delivery ID
+ : @param $signature Cryptographic signature
+ : @result JSON object
+ :)
 declare
   %rest:POST("{$data}")
   %rest:path("/webhook/github")

--- a/openapi-config.xml
+++ b/openapi-config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns="https://lab.sub.uni-goettingen.de/restxqopenapi">
+  <info>
+    <termsOfService>https://dracor.org</termsOfService>
+    <contact>
+      <email>ffischer@hse.ru</email>
+    </contact>
+  </info>
+  <servers>
+    <server url="http://localhost:8080/exist/restxq">
+      Local development server
+    </server>
+    <server url="https://dracor.org/api">
+      Production server
+    </server>
+  </servers>
+</config>

--- a/repo.xml
+++ b/repo.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <meta xmlns="http://exist-db.org/xquery/repo">
-  <description>Backend resources for dracor.org</description>
+  <description>RESTful API for the Drama Corpora Project (DraCor)</description>
   <author>Carsten Milling</author>
   <website>https://github.com/dracor-org/dracor-api</website>
   <status>alpha</status>
-  <license>GNU-LGPL</license>
+  <license ref="https://spdx.org/licenses/">Apache-2.0</license>
   <copyright>true</copyright>
   <type>application</type>
   <target>dracor</target>


### PR DESCRIPTION
This PR adds xqDoc comments to the RESTXQ functions defining the DraCor API and implements an `/openapi` endpoint providing an OpenAPI JSON document generated with *openapi4restxq*.

solves #59