### PR TITLE
Support 'notBefore' and 'notAfter' attributes for 'date' elements

### DIFF
--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -446,7 +446,7 @@ function api:index($corpusname) {
           let $name := tokenize($filename, "\.")[1]
           let $id := dutil:get-dracor-id($tei)
           let $subtitle := $tei//tei:titleStmt/tei:title[@type='sub'][1]/normalize-space()
-          let $dates := $tei//tei:bibl[@type="originalSource"]/tei:date
+          let $years := dutil:get-years-iso($tei)
           let $authors := dutil:get-authors($tei)
           let $play-uri :=
             $config:api-base || "/corpora/" || $corpusname || "/play/" || $name
@@ -483,9 +483,9 @@ function api:index($corpusname) {
                     /tei:idno[@type="URL"]/string()
                 }
               </sourceUrl>
-              <printYear>{$dates[@type="print"]/@when/string()}</printYear>
-              <premiereYear>{$dates[@type="premiere"]/@when/string()}</premiereYear>
-              <writtenYear>{$dates[@type="written"]/@when/string()}</writtenYear>
+              <printYear>{$years?print}</printYear>
+              <premiereYear>{$years?premiere}</premiereYear>
+              <writtenYear>{$years?written}</writtenYear>
               <networkSize>{$network-size}</networkSize>
               <networkdataCsvUrl>{$play-uri}/networkdata/csv</networkdataCsvUrl>
               <wikidataId>

--- a/modules/rdf.xqm
+++ b/modules/rdf.xqm
@@ -305,38 +305,38 @@ as element(rdf:RDF) {
       else ()
     
     (: Dates :)
-    
-    let $dates := $play//tei:bibl[@type="originalSource"]/tei:date
+    let $years := dutil:get-years-iso($play)
+    let $yn := dutil:get-normalized-year($play)
     
     let $normalisedYear :=
-      if (dutil:get-normalized-year($play) != "")
+      if ($yn != "")
       then
         <dracon:normalisedYear rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear">
-          {dutil:get-normalized-year($play)}
+          {$yn}
         </dracon:normalisedYear>
       else ()
     
     let $premiereYear :=
-      if ( $dates[@type="premiere"]/@when/string() != '')
+      if (matches($years?premiere, "^-?[0-9]{4}$"))
       then
         <dracon:premiereYear rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear">
-          {$dates[@type="premiere"]/@when/string()}
+          {$years?premiere}
         </dracon:premiereYear>
       else ()
     
     let $printYear :=
-      if ( $dates[@type="print"]/@when/string() !='' )
+      if (matches($years?print, "^-?[0-9]{4}$"))
       then
         <dracon:printYear rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear">
-          {$dates[@type="print"]/@when/string()}
+          {$years?print}
         </dracon:printYear>
       else ()
     
     let $writtenYear :=
-      if ( $dates[@type="written"]/@when/string() )
+      if (matches($years?written, "^-?[0-9]{4}$"))
       then
         <dracon:writtenYear rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear">
-          {$dates[@type="written"]/@when/string()}
+          {$years?written}
         </dracon:writtenYear>
       else ()
     

--- a/modules/util.xqm
+++ b/modules/util.xqm
@@ -328,7 +328,8 @@ declare function dutil:get-years ($tei as element(tei:TEI)*) as map(*) {
       $d/@notAfter/string()
     else
       $d/@notBefore/string()
-    return map:entry($type, $year)
+    return if (matches($year, "^-?[0-9]{4}$"))
+      then map:entry($type, $year) else ()
   )
 
   return $years
@@ -342,7 +343,7 @@ declare function dutil:get-years ($tei as element(tei:TEI)*) as map(*) {
  :)
 declare function dutil:get-normalized-year (
   $tei as element(tei:TEI)*
-) as item()* {
+) as xs:integer* {
   let $years := dutil:get-years($tei)
 
   let $written := $years?written
@@ -366,7 +367,7 @@ declare function dutil:get-normalized-year (
     else if ($written) then $written
     else $published
 
-  return $year
+  return xs:integer($year)
 };
 
 (:~


### PR DESCRIPTION
This PR implements support for `notBefore` and `notAfter` attributes in `date` elements describing authoring, premiere and print years. The attributes are taken into account for calculating the normalised year and are represented as ISO 8601 ranges when providing individual values in JSON output.

Resolves #106 
