### PR TITLE
Filter spoken text by role

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -882,6 +882,11 @@ paths:
               - related_with_passive
               - associated_with_active
               - associated_with_passive
+        - name: role
+          in: query
+          required: false
+          schema:
+            type: string
       responses:
         '200':
           description: Returns plain text document

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -1466,6 +1466,7 @@ function api:segmentation-csv($corpusname, $playname) {
  :   "parent_of_passive"|"lover_of_active"|"lover_of_passive"|
  :   "related_with_active"|"related_with_passive"|"associated_with_active"|
  :   "associated_with_passive")
+ : @param $role Role
  : @result text
  :)
 declare
@@ -1473,9 +1474,10 @@ declare
   %rest:path("/corpora/{$corpusname}/play/{$playname}/spoken-text")
   %rest:query-param("gender", "{$gender}")
   %rest:query-param("relation", "{$relation}")
+  %rest:query-param("role", "{$role}")
   %rest:produces("text/plain")
   %output:media-type("text/plain")
-function api:spoken-text($corpusname, $playname, $gender, $relation) {
+function api:spoken-text($corpusname, $playname, $gender, $relation, $role) {
   let $doc := dutil:get-doc($corpusname, $playname)
   let $genders := tokenize($gender, ',')
   return
@@ -1494,8 +1496,8 @@ function api:spoken-text($corpusname, $playname, $gender, $relation) {
         "gender must be ""FEMALE"", ""MALE"", or ""UNKNOWN"""
       )
     else
-      let $sp := if ($gender or $relation) then
-        dutil:get-speech-filtered($doc//tei:body, $gender, $relation)
+      let $sp := if ($gender or $relation or $role) then
+        dutil:get-speech-filtered($doc//tei:body, $gender, $relation, $role)
       else
         dutil:get-speech($doc//tei:body, ())
       let $txt := string-join(($sp/normalize-space(), ""), '&#10;')

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -1514,6 +1514,7 @@ declare function local:get-text-by-character ($doc) {
       tei:persName[@xml:id=$id]
     )
     let $gender := $label/parent::*/@sex/string()
+    let $role := $label/parent::*/@role/string()
     let $isGroup := if ($label/parent::tei:personGrp)
     then true() else false()
     let $sp := dutil:get-speech($doc//tei:body, $id)
@@ -1522,6 +1523,7 @@ declare function local:get-text-by-character ($doc) {
       "label": $label/text(),
       "isGroup": $isGroup,
       "gender": $gender,
+      "roles": array {tokenize($role, '\s+')},
       "text": array {for $l in $sp return $l/normalize-space()}
     }
   }

--- a/modules/util.xqm
+++ b/modules/util.xqm
@@ -185,7 +185,8 @@ declare function dutil:get-speech-by-gender (
 declare function dutil:get-speech-filtered (
   $parent as element(),
   $gender as xs:string*,
-  $relation as xs:string*
+  $relation as xs:string*,
+  $role as xs:string*
 ) as item()* {
   let $undirected := ("siblings", "friends", "spouses")
   let $directed := ("parent_of", "lover_of", "related_with", "associated_with")
@@ -193,12 +194,16 @@ declare function dutil:get-speech-filtered (
   let $passive := for $x in $directed return $x || '_passive'
   let $rel := replace($relation, '_(active|passive)$', '')
   let $genders := tokenize($gender, ',')
+  let $roles := tokenize($role, ',')
 
   let $listPerson := $parent/ancestor::tei:TEI//tei:particDesc/tei:listPerson
   let $relations := $listPerson/tei:listRelation[@type="personal"]
 
   let $ids := $listPerson/(tei:person|tei:personGrp)
-    [not($gender) or @sex = $genders]/@xml:id/string()
+    [
+      (not($gender) or @sex = $genders) and
+      (not($role) or tokenize(@role, '\s+') = $roles)
+    ]/@xml:id/string()
 
   let $filtered := for $id in $ids
     return if (not($relation)) then


### PR DESCRIPTION
This pull request adds a `role` parameter to the `/corpora/{corpusname}/play/{playname}/spoken-text` endpoint. It also adds a `roles` array to JSON returned from `/corpora/{corpusname}/play/{playname}/spoken-text-by-character`.

This resolves #105.