### PR TITLE
Revise genre attribution and identification of libretti

### DIFF
--- a/modules/config.xqm
+++ b/modules/config.xqm
@@ -70,6 +70,17 @@ declare variable $config:metrics-server :=
   xs:anyURI("http://localhost:8030/metrics/");
 
 (:~
+ : The Wikidata IDs for text classification currently recognized as text class
+ : codes in DraCor.
+ :)
+declare variable $config:wd-text-classes := map {
+  "Q40831": "Comedy",
+  "Q80930": "Tragedy",
+  "Q192881": "Tragicomedy",
+  "Q131084": "Libretto"
+};
+
+(:~
  : Resolve the given path using the current application context.
  : If the app resides in the file system,
  :)


### PR DESCRIPTION
This PR is a step towards loosening the tight coupling of genre attribution and identification of libretti (see https://github.com/dracor-org/dracor-api/issues/120#issuecomment-744015589). The current implementation exclusively uses the `classCode` element to determine the genre and completely ignores the `textClass/keywords` entirely (as, in fact, did the previous iteration). However, it introduces a [map of recognised genre relevant class codes](https://github.com/dracor-org/dracor-api/blob/73747be4d914a555a4e74698e8f9683f899fe32d/modules/config.xqm#L76). If any of these codes, except the one for libretto, has been attributed to a play, the respective label (currently `Tragedy`, `Comedy` or `Tragicomedy`) will be assigned to the `genre` field. If more than one of the recognised codes have been assigned, the label of the first one will be used as `genre`.

This implementation has the following advantages:

1. It allows for text classes other than the recognised ones to be attributed to a play without interfering with the genre attribution.
2. It even allows a genre to be assigned to a libretto. (Whether this makes sense scientifically is outside the scope of this implementation.)
3. Ignoring the keywords makes it unnecessary to ensure that the `keyword` and `classCode` are consistent. (As an aside, the [TEI documentation](https://www.tei-c.org/release/doc/tei-p5-doc/en/html/HD.html#HD43) does not seem to imply any defined relationship between `textClass/keywords` and `textClass/classCode` other than a shared `taxonomy`, which in the currently used markup is not provided.)

It may seem as a disadvantage that the map of recognised class codes needs to be updated, if we want to add a new text class relevant for genre attribution. One could also see it as an easy way to control what DraCor considers a genre.

Please test on staging.dracor.org and let me know if this makes sense. If so, we should probably document this somewhere.