### PR TITLE
Refactor author information

### DIFF
--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -475,6 +475,10 @@ function api:index($corpusname) {
                     <fullname>{$author?fullname}</fullname>
                     <shortname>{$author?shortname}</shortname>
                     {if ($author?key != "") then <key>{$author?key}</key> else ()}
+                    {
+                      for $name in $author?alsoKnownAs?*
+                      return <alsoKnownAs json:array="true">{$name}</alsoKnownAs>
+                    }
                   </authors>
               }
               <yearNormalized>{$yearNormalized}</yearNormalized>

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -470,8 +470,11 @@ function api:index($corpusname) {
               {
                 for $author in $authors
                 return
-                  <authors key="{$author?key}" json:array="true">
+                  <authors json:array="true">
                     <name>{$author?name}</name>
+                    <fullname>{$author?fullname}</fullname>
+                    <shortname>{$author?shortname}</shortname>
+                    {if ($author?key != "") then <key>{$author?key}</key> else ()}
                   </authors>
               }
               <yearNormalized>{$yearNormalized}</yearNormalized>

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -21,6 +21,8 @@ declare namespace rdf = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
 declare variable $api:metadata-columns := (
   "name",
   "id",
+  "firstAuthor",
+  "numOfCoAuthors",
   "yearNormalized",
   "size",
   "genre",
@@ -684,10 +686,11 @@ declare function api:get-corpus-meta-data-csv($corpusname) {
       let $header := concat(string-join($api:metadata-columns, ","), "&#10;")
       let $rows :=
         for $m in $meta return concat(
+          '"',
           string-join((
             for $c in $api:metadata-columns
-            return if (count($m($c)) = 0) then '' else $m($c)
-          ), ','), "&#10;")
+            return if (count($m($c)) = 0) then '' else dutil:csv-escape($m($c))
+          ), '","'), '"&#10;')
       return ($header, $rows)
 };
 

--- a/modules/util.xqm
+++ b/modules/util.xqm
@@ -521,6 +521,7 @@ declare function dutil:get-corpus-meta-data(
   let $id := dutil:get-dracor-id($tei)
   let $name := tokenize($filename, "\.")[1]
   let $years := dutil:get-years-iso($tei)
+  let $authors := dutil:get-authors($tei)
   
   let $text-classes := dutil:get-text-classes($tei)
 
@@ -552,6 +553,8 @@ declare function dutil:get-corpus-meta-data(
     "playName": $name,
     "genre": dutil:get-genre($text-classes),
     "libretto": $text-classes = 'Libretto',
+    "firstAuthor": $authors[1]?shortname,
+    "numOfCoAuthors": if(count($authors) > 0) then count($authors) - 1 else 0,
     "maxDegreeIds": if(count($max-degree-ids) < 4) then
       string-join($max-degree-ids, "|")
     else

--- a/modules/util.xqm
+++ b/modules/util.xqm
@@ -647,6 +647,11 @@ declare function dutil:get-authors($tei as node()) as map()* {
       "type": $type
     }
   }
+  let $aka := array {
+    for $name in $author/tei:persName[position() > 1]
+    return $name => normalize-space()
+  }
+
   (:
     FIXME: support for author/@key can be removed once we fully transitioned to
     author/idno
@@ -657,13 +662,13 @@ declare function dutil:get-authors($tei as node()) as map()* {
     $refs?1?type || ":" || $refs?1?ref
   else ()
 
-  return map {
+  return map:merge((map {
     "name": $name,
     "fullname": $fullname,
     "shortname": $shortname,
     "key": $key,
     "refs": $refs
-  }
+  }, if (array:size($aka) > 0) then map {"alsoKnownAs": $aka} else ()))
 };
 
 (:~


### PR DESCRIPTION
These changes adopt the new convention for tagging author names conceived in #119 and adds the following new fields to the author entries in play details and corpus listing:

- `shortname` (generally the surname, in case of multiple surnames the one having a `@sort="1"` or the first)
- `fullname` (the text content of the first `persName` with space normalized)
- `alsoKnownAs` (an array of alternative names if any)
- `refs` (an array of ID references provided by `idno` elements)

The PR also adds the columns `firstAuthor` and `numOfCoAuthors` to the corpus meta data.

Resolves #119.