### PR TITLE
Harmonise year

### DIFF
--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -486,9 +486,17 @@ function api:corpus-index($corpusname) {
               /tei:idno[@type="URL"][1]/string()
           ),
           map:entry("yearNormalized", $yearNormalized),
+          map:entry("yearPrinted", $years?print),
+          map:entry("yearPremiered", $years?premiere),
+          map:entry("yearWritten", $years?written),
+          (:
+            FIXME: the following year properties are deprecated and should be
+            removed in a future release
+           :)
           map:entry("printYear", $years?print),
           map:entry("premiereYear", $years?premiere),
           map:entry("writtenYear", $years?written),
+
           map:entry("networkSize", $network-size),
           map:entry("networkdataCsvUrl", $play-uri || "/networkdata/csv"),
           map:entry("wikidataId", dutil:get-play-wikidata-id($tei))


### PR DESCRIPTION
This PR renames `{print,premiere,written}Year` to `year{Printed,Premiered,Written}` and makes sure these properties provide years only even where a full ISO date may be given in the TEI.

resolves #179