### PR TITLE
ci: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# dependabot
+# Ref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# ------------------------------------------------------------------------------
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly
+  groups:
+    # open a single pull-request for all GitHub actions updates
+    github-actions:
+      patterns:
+      - '*'


### PR DESCRIPTION
This PR proposes the following changes:

- add a config file for automatic version updates with Dependabot
- the bot will create a single pr with updates of the github actions once a month

I recommend merging this after #222, because then Dependabot will update the version comment after the commit SHAs as well.

What do you think?

