### PR TITLE
Extend API tests

### DIFF
--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -23,12 +23,12 @@ jobs:
       - name: Start the docker-compose stack
         run: docker compose up --detach --wait
       - name: Test if /info returns a response
-        run: curl --verbose http://localhost:8080/exist/restxq/v1/info
+        run: curl --verbose http://localhost:8081/exist/restxq/v1/info
       - name: Add test corpus
         run: |
           curl \
             --request POST \
-            --url http://localhost:8080/exist/restxq/v1/corpora \
+            --url http://localhost:8081/exist/restxq/v1/corpora \
             --user admin: \
             --header 'Content-Type: application/json' \
             --data @./corpora/test.json
@@ -36,14 +36,14 @@ jobs:
         run: |
           curl \
             --request POST \
-            --url http://localhost:8080/exist/restxq/v1/corpora/test \
+            --url http://localhost:8081/exist/restxq/v1/corpora/test \
             --user admin: \
             --header 'Content-Type: application/json' \
             --data '{"load": true}'
       - name: Wait 10 seconds for corpus data loading to complete
         run: sleep 10
       - name: Test if corpus returns a response
-        run: curl --verbose http://localhost:8080/exist/restxq/v1/corpora/test
+        run: curl --verbose http://localhost:8081/exist/restxq/v1/corpora/test
 
       - name: Test API with schemathesis
         # Refs:
@@ -52,8 +52,8 @@ jobs:
         uses: schemathesis/action@cd782ab11a0ae6358e38b7adaaf942a53dbe9368 # v1.0.3
         with:
           api-name: dracor-api
-          schema: http://localhost:8080/exist/restxq/v1/openapi.yaml
-          base-url: http://localhost:8080/exist/restxq/v1/
+          schema: http://localhost:8081/exist/restxq/v1/openapi.yaml
+          base-url: http://localhost:8081/exist/restxq/v1/
           # OPTIONAL. Your Schemathesis.io token
           token: ${{ secrets.SCHEMATHESIS_TOKEN }}
           # OPTIONAL. List of Schemathesis checks to run. Defaults to `all`

--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -59,7 +59,7 @@ jobs:
           # OPTIONAL. List of Schemathesis checks to run. Defaults to `all`
           # if multiple checks should be used, use a comma seperated string,
           # e.g. "not_a_server_error,status_code_conformance"
-          checks: not_a_server_error
+          checks: not_a_server_error,content_type_conformance,response_headers_conformance,response_schema_conformance
           # OPTIONAL. Whether you'd like to see the results in a Web UI
           # Defaults to `true`
           report: true

--- a/api.yaml
+++ b/api.yaml
@@ -227,7 +227,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Corpus'
         '404':
-          description: Corpus not found
+          description: Unknown corpus
     post:
       summary: Load corpus data from its repository
       description: >-
@@ -263,7 +263,7 @@ paths:
                   "message": "corpus update scheduled"
                 }
         '404':
-          description: Corpus not found
+          description: Unknown corpus
         '409':
           description: >-
             Corpus update could not be scheduled.
@@ -279,7 +279,7 @@ paths:
         '200':
           description: Corpus deleted
         '404':
-          description: Corpus not found
+          description: Unknown corpus
 
 
   /corpora/{corpusname}/metadata:
@@ -301,6 +301,8 @@ paths:
             text/csv:
               schema:
                 type: string
+        '404':
+          description: Unknown corpus
 
   /corpora/{corpusname}/metadata/csv:
     get:
@@ -319,6 +321,8 @@ paths:
                 "achat-ein-april-scherz","ger000637","Q121463020","Achat","0","Ein April-Scherz","Original-Lustspiel in einem Akt","Comedy","https://books.google.com/books?id=qHNIAQAAMAAJ&pg=PA45","Vereins-Buchhandlung","Berlin","1842","30","1842","6","false","0.8444444444444444","0.8","1.2","fraeulein|rittmeister","4","2","","1842","5","6","3","3","0","0","1","12","","22","0","0","6888","6681","411","518","0"
               schema:
                 type: string
+        '404':
+          description: Unknown corpus
 
   /corpora/{corpusname}/plays/{playname}:
     get:
@@ -335,6 +339,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Play'
+        '404':
+          description: Unknown play (or corpus)
     delete:
       summary: Remove a single play from the corpus
       operationId: play-delete
@@ -346,7 +352,7 @@ paths:
         '200':
           description: Play has been removed
         '404':
-          description: No such play under this URI
+          description: Unknown play (or corpus)
 
   /corpora/{corpusname}/plays/{playname}/metrics:
     get:
@@ -363,6 +369,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PlayMetrics'
+        '404':
+          description: Unknown play (or corpus)
 
   /corpora/{corpusname}/plays/{playname}/tei:
     get:
@@ -379,6 +387,8 @@ paths:
             application/xml:
               schema:
                 type: string
+        '404':
+          description: Unknown play (or corpus)
     put:
       summary: Add new or update existing TEI document
       description: |
@@ -485,6 +495,8 @@ paths:
                 "ammos_fedorovich_ljapkin_tjapkin","Аммос Федорович","MALE","false","8","49","748"
                 "artemij_filippovich_zemljanika","Артемий Филиппович Земляника","MALE","false","9","50","735"
                 "luka_lukich","Лука Лукич","MALE","false","8","24","291"
+        '404':
+          description: Unknown play (or corpus)
 
   /corpora/{corpusname}/plays/{playname}/characters/csv:
     get:
@@ -507,6 +519,8 @@ paths:
                 "ammos_fedorovich_ljapkin_tjapkin","Аммос Федорович","MALE","false","8","49","748"
                 "artemij_filippovich_zemljanika","Артемий Филиппович Земляника","MALE","false","9","50","735"
                 "luka_lukich","Лука Лукич","MALE","false","8","24","291"
+        '404':
+          description: Unknown play (or corpus)
 
   /corpora/{corpusname}/plays/{playname}/networkdata/csv:
     get:
@@ -531,6 +545,8 @@ paths:
                 choros,Undirected,xerxes,2
                 atossa,Undirected,angelos,2
                 atossa,Undirected,dareios,1
+        '404':
+          description: Unknown play (or corpus)
 
   /corpora/{corpusname}/plays/{playname}/networkdata/gexf:
     get:
@@ -547,6 +563,8 @@ paths:
             application/xml:
               schema:
                 type: string
+        '404':
+          description: Unknown play (or corpus)
 
   /corpora/{corpusname}/plays/{playname}/networkdata/graphml:
     get:
@@ -563,6 +581,8 @@ paths:
             application/xml:
               schema:
                 type: string
+        '404':
+          description: Unknown play (or corpus)
 
   /corpora/{corpusname}/plays/{playname}/relations/csv:
     get:
@@ -853,6 +873,8 @@ paths:
             text/plain:
               schema:
                 type: string
+        '404':
+          description: Unknown play (or corpus)
 
   /corpora/{corpusname}/plays/{playname}/spoken-text-by-character:
     get:
@@ -874,6 +896,8 @@ paths:
             text/csv:
               schema:
                 type: string
+        '404':
+          description: Unknown play (or corpus)
 
   /corpora/{corpusname}/plays/{playname}/stage-directions:
     get:
@@ -890,6 +914,8 @@ paths:
             text/plain:
               schema:
                 type: string
+        '404':
+          description: Unknown play (or corpus)
 
   /corpora/{corpusname}/plays/{playname}/stage-directions-with-speakers:
     get:
@@ -906,6 +932,8 @@ paths:
             text/plain:
               schema:
                 type: string
+        '404':
+          description: Unknown play (or corpus)
 
   /id/{id}:
     get:
@@ -927,7 +955,7 @@ paths:
         '303':
           description: Redirect to RDF or JSON resource or dracor.org URL.
         '404':
-          description: No play found for this ID
+          description: No play found by this ID
 
   /character/{id}:
     get:
@@ -952,6 +980,8 @@ paths:
                   $ref: '#/components/schemas/PlayWithWikidataCharacter'
         '400':
           description: Invalid character ID.
+        '404':
+          description: Unknown character
 
   /wikidata/author/{id}:
     get:
@@ -973,7 +1003,7 @@ paths:
               schema:
                 type: object
         '404':
-          description: Invalid or non existing author ID
+          description: Invalid or unknown author ID
           content:
             application/json:
               schema:

--- a/compose.override.yml
+++ b/compose.override.yml
@@ -1,0 +1,13 @@
+services:
+  api:
+    ports:
+      - 8080:8080
+  fuseki:
+    ports:
+      - 3030:3030
+  metrics:
+    ports:
+      - 8030:8030
+  frontend:
+    ports:
+      - 8088:80

--- a/compose.t.yml
+++ b/compose.t.yml
@@ -13,9 +13,12 @@ services:
         - FUSEKI_SECRET=qwerty
         - GITHUB_WEBHOOK_SECRET=qwerty
     environment:
-      # set back to default
-      - DRACOR_API_BASE=http://localhost:8080/exist/restxq/v1
+      - DRACOR_API_BASE=http://localhost:8081/exist/restxq/v1
       - EXIST_PASSWORD=
+    ports:
+      - 8081:8080
   frontend:
     profiles:
       - fulltest
+    ports:
+      - 8089:80

--- a/compose.yml
+++ b/compose.yml
@@ -5,8 +5,6 @@ services:
     environment:
       - DRACOR_API_BASE=http://localhost:8088/api/v1
       - EXIST_PASSWORD
-    ports:
-      - 8080:8080
     depends_on:
       - fuseki
       - metrics
@@ -14,18 +12,12 @@ services:
     image: dracor/fuseki:1.1.2
     environment:
       - ADMIN_PASSWORD=qwerty
-    ports:
-      - 3030:3030
   metrics:
     image: dracor/metrics:1.3.3
-    ports:
-      - 8030:8030
   frontend:
     image: dracor/frontend:2.1.0
     environment:
       DRACOR_API_HOST: http://api:8080
       DRACOR_API_PREFIX: /exist/restxq/v1
-    ports:
-      - 8088:80
     depends_on:
       - api

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -514,7 +514,7 @@ function api:corpus-index($corpusname) {
           map:entry("yearPremiered", $years?premiere),
           if($premiere-date) then map:entry("datePremiered", $premiere-date) else (),
           map:entry("yearWritten", $years?written),
-          map:entry("networkSize", $network-size),
+          map:entry("networkSize", xs:integer($network-size)),
           map:entry("networkdataCsvUrl", $play-uri || "/networkdata/csv"),
           map:entry("wikidataId", dutil:get-play-wikidata-id($tei))
         ))

--- a/test/schemathesis.sh
+++ b/test/schemathesis.sh
@@ -1,7 +1,7 @@
 # This should reproduce the test in the GitHub workflow.
 
 schemathesis run http://localhost:8081/exist/restxq/v1/openapi.yaml \
-  --checks not_a_server_error,content_type_conformance,response_headers_conformance,response_schema_conformance \
+  --exclude-checks status_code_conformance \
   --report \
   --hypothesis-max-examples 50 \
   --auth admin: \

--- a/test/schemathesis.sh
+++ b/test/schemathesis.sh
@@ -1,6 +1,6 @@
 # This should reproduce the test in the GitHub workflow.
 
-schemathesis run http://localhost:8088/api/v1/openapi.yaml \
+schemathesis run http://localhost:8080/exist/restxq/v1/openapi.yaml \
   --checks not_a_server_error \
   --report \
   --hypothesis-max-examples 50 \

--- a/test/schemathesis.sh
+++ b/test/schemathesis.sh
@@ -1,6 +1,6 @@
 # This should reproduce the test in the GitHub workflow.
 
-schemathesis run http://localhost:8080/exist/restxq/v1/openapi.yaml \
+schemathesis run http://localhost:8081/exist/restxq/v1/openapi.yaml \
   --checks not_a_server_error,content_type_conformance,response_headers_conformance,response_schema_conformance \
   --report \
   --hypothesis-max-examples 50 \

--- a/test/schemathesis.sh
+++ b/test/schemathesis.sh
@@ -1,7 +1,7 @@
 # This should reproduce the test in the GitHub workflow.
 
 schemathesis run http://localhost:8080/exist/restxq/v1/openapi.yaml \
-  --checks not_a_server_error \
+  --checks not_a_server_error,content_type_conformance,response_headers_conformance,response_schema_conformance \
   --report \
   --hypothesis-max-examples 50 \
   --auth admin: \


### PR DESCRIPTION
This PR adds documentation for possible 404 responses, sets up a test instance that can be started in parallel to a development one (port 8081), and runs all test types except `status_code_conformance`. The latter still yields several undocumented 400 Bad request responses.

see #236