### PR TITLE
Restructure database file hierarchy

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -1084,7 +1084,7 @@ paths:
               example: |
                 {
                   "message": "Delivery accepted.",
-                  "result": "/db/data/dracor/webhook/20190121213010-xxx.xml",
+                  "result": "/db/dracor/webhook/20190121213010-xxx.xml",
                   "scheduled": true
                 }
 

--- a/modules/config.xqm
+++ b/modules/config.xqm
@@ -31,8 +31,12 @@ declare variable $config:app-root :=
         substring-before($modulePath, "/modules")
 ;
 
-declare variable $config:file := "/db/data/dracor/config-v1.xml";
-declare variable $config:secrets-file := "/db/data/dracor/secrets.xml";
+declare variable $config:dracor-root := "/db/dracor";
+declare variable $config:corpora-root := $config:dracor-root || "/corpora";
+declare variable $config:webhook-root := $config:dracor-root || "/webhook";
+
+declare variable $config:file := $config:dracor-root || "/config-v1.xml";
+declare variable $config:secrets-file := $config:dracor-root || "/secrets.xml";
 
 (:
   The base URL under which the REST API is hosted.
@@ -42,16 +46,6 @@ declare variable $config:secrets-file := "/db/data/dracor/secrets.xml";
 :)
 declare variable $config:api-base :=
   doc($config:file)//api-base/normalize-space();
-
-declare variable $config:data-root := "/db/data/dracor/tei";
-
-declare variable $config:rdf-root := "/db/data/dracor/rdf";
-
-declare variable $config:metrics-root := "/db/data/dracor/metrics";
-
-declare variable $config:sitelinks-root := "/db/data/dracor/sitelinks";
-
-declare variable $config:webhook-root := "/db/data/dracor/webhook";
 
 declare variable $config:webhook-secret :=
   doc($config:secrets-file)//gh-webhook/normalize-space();

--- a/modules/load.xqm
+++ b/modules/load.xqm
@@ -84,14 +84,12 @@ as xs:string* {
           let $body := $response[2]
           let $zip := xs:base64Binary($body)
           return (
-            (: FIXME: just remove the corpus collection :)
-            (: remove TEI documents :)
-            for $tei in collection($corpus-collection)/tei:TEI
-            let $resource := tokenize($tei/base-uri(), '/')[last()]
-            return (
-              util:log-system-out("removing " || $resource),
-              xmldb:remove($corpus-collection, $resource)
-            ),
+            util:log-system-out("removing " || $corpus-collection),
+            xmldb:remove($corpus-collection),
+
+            (: Re-create corpus :)
+            util:log-system-out("recreating " || $name),
+            dutil:create-corpus($info),
 
             (: clear fuseki graph :)
             drdf:fuseki-clear-graph($name),

--- a/modules/rdf.xqm
+++ b/modules/rdf.xqm
@@ -444,11 +444,10 @@ as element(rdf:RDF) {
 declare function drdf:update($url as xs:string) {
   let $rdf := drdf:play-to-rdf(doc($url)/tei:TEI)
   let $paths := dutil:filepaths($url)
-  let $collection := $paths?collections?rdf
-  let $resource := $paths?playname || ".rdf.xml"
+  let $collection := $paths?collections?play
   return (
-    util:log('info', ('RDF update: ', $collection, "/", $resource)),
-    xmldb:store($collection, $resource, $rdf) => xs:anyURI() => drdf:fuseki()
+    util:log-system-out("RDF update: " || $paths?files?rdf),
+    xmldb:store($collection, "rdf.xml", $rdf) => xs:anyURI() => drdf:fuseki()
   )
 };
 
@@ -457,7 +456,7 @@ declare function drdf:update($url as xs:string) {
 :)
 declare function drdf:update() as xs:string* {
   let $l := util:log-system-out("Updating RDF files")
-  for $tei in collection($config:data-root)//tei:TEI
+  for $tei in collection($config:corpora-root)//tei:TEI
   let $url := $tei/base-uri()
   return drdf:update($url)
 };

--- a/modules/trigger.xqm
+++ b/modules/trigger.xqm
@@ -12,43 +12,29 @@ declare namespace tei = "http://www.tei-c.org/ns/1.0";
 
 
 declare function trigger:after-create-document($url as xs:anyURI) {
-  if (doc($url)/tei:TEI) then
+  if (ends-with($url, "/tei.xml") and doc($url)/tei:TEI) then
     (
       util:log-system-out("running CREATION TRIGGER for " || $url),
       metrics:update($url),
       metrics:update-sitelinks($url),
       drdf:update($url)
     )
-  else (
-    util:log-system-out("ignoring creation of " || $url)
-  )
+  else ()
 };
 
 declare function trigger:after-update-document($url as xs:anyURI) {
-  if (doc($url)/tei:TEI) then
+  if (ends-with($url, "/tei.xml") and doc($url)/tei:TEI) then
     (
       util:log-system-out("running UPDATE TRIGGER for " || $url),
       metrics:update($url),
       metrics:update-sitelinks($url),
       drdf:update($url)
     )
-  else (
-    util:log-system-out("ignoring update of " || $url)
-  )
+  else ()
 };
 
 declare function trigger:before-delete-document($url as xs:anyURI) {
-  if (doc($url)/tei:TEI) then
-    let $paths := dutil:filepaths($url)
-    let $id := dutil:get-play-wikidata-id(doc($url)/tei:TEI)
-    return try {
-      if ($id) then xmldb:remove($paths?collections?sitelinks, $id || '.xml') else (),
-      xmldb:remove($paths?collections?metrics, $paths?filename),
-      xmldb:remove($paths?collections?rdf, $paths?playname || ".rdf.xml")
-    } catch * {
-      util:log-system-out($err:description)
-    }
-  else (
-    util:log-system-out("ignoring deletion of " || $url)
-  )
+  if (ends-with($url, "/tei.xml")) then
+    util:log-system-out("about to DELETE " || $url)
+  else ()
 };

--- a/modules/util.xqm
+++ b/modules/util.xqm
@@ -468,10 +468,10 @@ declare function dutil:get-corpus-info(
   let $header := $corpus/tei:teiHeader
   let $name := $header//tei:publicationStmt/tei:idno[
     @type="URI" and @xml:base="https://dracor.org/"
-  ]/text()
-  let $title := $header/tei:fileDesc/tei:titleStmt/tei:title[1]/text()
-  let $acronym := $header/tei:fileDesc/tei:titleStmt/tei:title[@type="acronym"]/text()
-  let $repo := $header//tei:publicationStmt/tei:idno[@type="repo"]/text()
+  ][1]/string()
+  let $title := $header/tei:fileDesc/tei:titleStmt/tei:title[1]/string()
+  let $acronym := $header/tei:fileDesc/tei:titleStmt/tei:title[@type="acronym"][1]/string()
+  let $repo := $header//tei:publicationStmt/tei:idno[@type="repo"][1]/string()
   let $projectDesc := $header/tei:encodingDesc/tei:projectDesc
   let $licence := $header//tei:availability/tei:licence
   let $description := if ($projectDesc) then (

--- a/modules/util.xqm
+++ b/modules/util.xqm
@@ -20,27 +20,10 @@ declare namespace json = "http://www.w3.org/2013/XSL/json";
  :)
 declare function dutil:filepaths ($url as xs:string) as map() {
   let $segments := tokenize($url, "/")
-  let $corpusname := $segments[last() - 1]
+  let $corpusname := $segments[last() - 2]
+  let $playname := $segments[last() - 1]
   let $filename := $segments[last()]
-  let $playname := substring-before($filename, ".xml")
-  return map {
-    "filename": $filename,
-    "playname": $playname,
-    "corpusname": $corpusname,
-    "collections": map {
-      "tei": $config:data-root || "/" || $corpusname,
-      "metrics": $config:metrics-root || "/" || $corpusname,
-      "sitelinks": $config:sitelinks-root || "/" || $corpusname,
-      "rdf": $config:rdf-root || "/" || $corpusname
-    },
-    "files": map {
-      "tei": $config:data-root || "/" || $corpusname || "/" || $filename,
-      "metrics": $config:metrics-root || "/" || $corpusname || "/" || $filename,
-      "rdf": $config:rdf-root || "/" || $corpusname || "/" || $playname
-        || ".rdf.xml"
-    },
-    "url": $url
-  }
+  return dutil:filepaths($corpusname, $playname, $filename)
 };
 
 (:~
@@ -54,24 +37,39 @@ declare function dutil:filepaths (
   $corpusname as xs:string,
   $playname as xs:string
 ) as map() {
-  let $filename := $playname || ".xml"
+  dutil:filepaths($corpusname, $playname, "tei.xml")
+};
+
+(:~
+ : Provide map of files and paths related to a play.
+ :
+ : @param $corpusname
+ : @param $playname
+ : @param $filename
+ : @return map()
+ :)
+declare function dutil:filepaths (
+  $corpusname as xs:string,
+  $playname as xs:string,
+  $filename as xs:string
+) as map() {
+  let $playpath := $config:corpora-root || "/" || $corpusname || "/" || $playname
+  let $url := $playpath || "/" || $filename
   return map {
+    "url": $url,
     "filename": $filename,
     "playname": $playname,
     "corpusname": $corpusname,
     "collections": map {
-      "tei": $config:data-root || "/" || $corpusname,
-      "metrics": $config:metrics-root || "/" || $corpusname,
-      "rdf": $config:rdf-root || "/" || $corpusname,
-      "sitelinks": $config:sitelinks-root || "/" || $corpusname
+      "corpus": $config:corpora-root || "/" || $corpusname,
+      "play": $playpath
     },
     "files": map {
-      "tei": $config:data-root || "/" || $corpusname || "/" || $filename,
-      "metrics": $config:metrics-root || "/" || $corpusname || "/" || $filename,
-      "rdf": $config:rdf-root || "/" || $corpusname || "/" || $playname
-        || ".rdf.xml"
-    },
-    "url": $config:data-root || "/" || $corpusname || "/" || $filename
+      "tei": $playpath || "/tei.xml",
+      "metrics": $playpath || "/metrics.xml",
+      "rdf": $playpath || "/rdf.xml",
+      "sitelinks": $playpath || "/sitelinks.xml"
+    }
   }
 };
 
@@ -85,10 +83,8 @@ declare function dutil:get-doc(
   $corpusname as xs:string,
   $playname as xs:string
 ) as node()* {
-  let $doc := doc(
-    $config:data-root || "/" || $corpusname || "/" || $playname || ".xml"
-  )
-  return $doc
+  let $paths := dutil:filepaths($corpusname, $playname)
+  return doc($paths?files?tei)
 };
 
 (:~
@@ -419,7 +415,7 @@ declare function dutil:count-sitelinks(
   $wikidata-id as xs:string*,
   $corpusname as xs:string
 ) {
-  let $col := concat($config:sitelinks-root, "/", $corpusname)
+  let $col := concat($config:corpora-root, "/", $corpusname)
   return if($wikidata-id) then
     count(collection($col)/sitelinks[@id=$wikidata-id]/uri)
   else ()
@@ -434,7 +430,7 @@ declare function dutil:count-sitelinks(
 declare function dutil:get-corpus(
   $corpusname as xs:string
 ) as element()* {
-  collection($config:data-root)//tei:teiCorpus[
+  collection($config:corpora-root)//tei:teiCorpus[
     tei:teiHeader//tei:publicationStmt/tei:idno[
       @type="URI" and
       @xml:base="https://dracor.org/" and
@@ -550,19 +546,12 @@ declare function dutil:get-genre($text-classes as xs:string*) as xs:string? {
 declare function dutil:get-corpus-meta-data(
   $corpusname as xs:string
 ) as map(*)* {
-  let $metrics-collection := concat($config:metrics-root, "/", $corpusname)
-  let $metrics := for $s in collection($metrics-collection)//metrics
-    let $uri := base-uri($s)
-    let $fname := tokenize($uri, "/")[last()]
-    let $name := tokenize($fname, "\.")[1]
-    return <metrics name="{$name}">{$s/*}</metrics>
-  (: return $metrics :)
-  let $collection := concat($config:data-root, "/", $corpusname)
+  let $collection := concat($config:corpora-root, "/", $corpusname)
 
   for $tei in collection($collection)//tei:TEI
-  let $filename := tokenize(base-uri($tei), "/")[last()]
   let $id := dutil:get-dracor-id($tei)
-  let $name := tokenize($filename, "\.")[1]
+  let $paths := dutil:filepaths(base-uri($tei))
+  let $name := $paths?playname
   let $years := dutil:get-years-iso($tei)
   let $authors := dutil:get-authors($tei)
   let $titles := dutil:get-titles($tei)
@@ -580,13 +569,13 @@ declare function dutil:get-corpus-meta-data(
   let $num-p := count($tei//tei:body//tei:sp//tei:p)
   let $num-l := count($tei//tei:body//tei:sp//tei:l)
 
-  let $stat := $metrics[@name=$name]
-  let $max-degree-ids := tokenize($stat/network/maxDegreeIds)
+  let $metrics := doc($paths?files?metrics)/metrics
+  let $max-degree-ids := tokenize($metrics/network/maxDegreeIds)
   let $wikidata-id := dutil:get-play-wikidata-id($tei)
   let $sitelink-count := dutil:count-sitelinks($wikidata-id, $corpusname)
 
   let $networkmetrics := map:merge(
-    for $s in $stat/network/*[not(name() = ("maxDegreeIds", "nodes"))]
+    for $s in $metrics/network/*[not(name() = ("maxDegreeIds", "nodes"))]
     let $v := $s/text()
     return map:entry(
       $s/name(),
@@ -610,7 +599,6 @@ declare function dutil:get-corpus-meta-data(
     if ($scope and number($scope/@to) and number($scope/@from))
     then number($scope/@to) - number($scope/@from) + 1
     else ()
-
 
   let $meta := map {
     "id": $id,
@@ -636,9 +624,9 @@ declare function dutil:get-corpus-meta-data(
     "numOfP": $num-p,
     "numOfL": $num-l,
     "wikipediaLinkCount": $sitelink-count,
-    "wordCountText": xs:integer($stat/text/string()),
-    "wordCountSp": xs:integer($stat/sp/string()),
-    "wordCountStage": xs:integer($stat/stage/string()),
+    "wordCountText": xs:integer($metrics/text/string()),
+    "wordCountSp": xs:integer($metrics/sp/string()),
+    "wordCountStage": xs:integer($metrics/stage/string()),
     "datePremiered": dutil:get-premiere-date($tei),
     "yearWritten": $years?written,
     "yearPremiered": $years?premiere,
@@ -652,7 +640,7 @@ declare function dutil:get-corpus-meta-data(
     "originalSourceYear": $origSourceYear,
     "originalSourceNumberOfPages": $origSourceNumPages
   }
-  order by $filename
+  order by $name
   return map:merge(($meta, $networkmetrics))
 };
 
@@ -914,8 +902,8 @@ declare function dutil:get-play-wikidata-id ($tei as element(tei:TEI)) {
  : @param $corpus Corpus name
  :)
 declare function dutil:get-play-wikidata-ids ($corpus as xs:string) {
-  let $data-col := $config:data-root || '/' || $corpus
-  for $uri in collection($data-col)
+  let $collection := $config:corpora-root || '/' || $corpus
+  for $uri in collection($collection)
     /tei:TEI//tei:standOff/tei:listRelation
       /tei:relation[@name="wikidata"]/@passive/string()
   return if (starts-with($uri, 'http://www.wikidata.org/entity/')) then
@@ -1231,7 +1219,7 @@ declare function dutil:get-relations (
  :)
 declare function dutil:get-plays-with-character ($id as xs:string) {
   let $wd-uri := "http://www.wikidata.org/entity/" || $id
-  let $plays := collection($config:data-root)
+  let $plays := collection($config:corpora-root)
     /tei:TEI[.//tei:person[@ana=$wd-uri]]
   return array {
     for $tei in $plays
@@ -1258,4 +1246,89 @@ declare function dutil:get-plays-with-character ($id as xs:string) {
 declare function dutil:csv-escape($string as xs:string) as xs:string {
   replace($string, '"', '""')
   (: replace($string, '\(', '((') :)
+};
+
+(:~
+ : Translate DraCor ID to URL
+ :
+ : @param $id DraCor ID
+ : @param $accept MIME type
+ :)
+declare function dutil:id-to-url (
+  $id as xs:string,
+  $accept as xs:string*
+) {
+  let $tei := collection($config:corpora-root)/tei:TEI[@xml:id = $id][1]
+
+  return if ($tei) then
+    let $paths := dutil:filepaths(base-uri($tei))
+    let $corpus := $paths?corpusname
+    let $play := $paths?playname
+    let $url := $config:api-base || "/corpora/" || $corpus || "/plays/" || $play
+
+    return if ($accept = "application/json") then
+      $url
+    else if ($accept = "application/rdf+xml") then
+      $url || "/rdf"
+    else
+      let $p := tokenize($config:api-base, '/')
+      return $p[1] || '//' || $p[3] || '/' || $corpus || "/" || $play
+  else ()
+};
+
+(:~
+ : Create new corpus collection
+ :
+ : @param $corpus Map with corpus description
+ :)
+declare function dutil:create-corpus($corpus as map()) {
+  let $xml :=
+    <teiCorpus xmlns="http://www.tei-c.org/ns/1.0">
+      <teiHeader>
+        <fileDesc>
+          <titleStmt>
+            <title>{$corpus?title}</title>
+          </titleStmt>
+          <publicationStmt>
+            <idno type="URI" xml:base="https://dracor.org/">{$corpus?name}</idno>
+            {
+              if ($corpus?repository)
+              then <idno type="repo">{$corpus?repository}</idno>
+              else ()
+            }
+          </publicationStmt>
+        </fileDesc>
+        {if ($corpus?description) then (
+          <encodingDesc>
+            <projectDesc>
+              {
+                for $p in tokenize($corpus?description, "&#10;&#10;")
+                return <p>{$p}</p>
+              }
+            </projectDesc>
+          </encodingDesc>
+        ) else ()}
+      </teiHeader>
+    </teiCorpus>
+
+  return dutil:create-corpus($corpus?name, $xml)
+};
+
+(:~
+ : Create new corpus collection
+ :
+ : @param $name Corpus name
+ : @param $xml Corpus description
+ :)
+declare function dutil:create-corpus(
+  $name as xs:string,
+  $xml as element(tei:teiCorpus)
+) {
+  util:log-system-out("creating corpus"),
+  util:log-system-out($xml),
+  xmldb:store(
+    xmldb:create-collection($config:corpora-root, $name),
+    "corpus.xml",
+    $xml
+  )
 };

--- a/modules/webhook.xqm
+++ b/modules/webhook.xqm
@@ -29,7 +29,7 @@ declare function local:check-signature (
 };
 
 declare function local:get-corpus ($repo-url as xs:string) as element()? {
-  collection($config:data-root)//tei:teiCorpus[
+  collection($config:corpora-root)//tei:teiCorpus[
     tei:teiHeader//tei:publicationStmt/tei:idno[@type="repo" and . = $repo-url]
   ]
 };

--- a/modules/wikidata.xqm
+++ b/modules/wikidata.xqm
@@ -104,7 +104,7 @@ WHERE {
 declare function wd:mixnmatch() {
   (
     "id,name,q&#10;",
-    for $tei in collection($config:data-root)/tei:TEI[@xml:id]
+    for $tei in collection($config:corpora-root)/tei:TEI[@xml:id]
     let $id := $tei/@xml:id/string()
     let $titles := dutil:get-titles($tei)
     let $q := dutil:get-play-wikidata-id($tei)

--- a/pre-install.xq
+++ b/pre-install.xq
@@ -34,12 +34,9 @@ local:mkcol("/db/system/config", $target),
 xdb:store-files-from-pattern(
   concat("/db/system/config", $target), $dir, "collection.xconf"
 ),
-xdb:create-collection("/", $config:data-root),
-local:mkcol("/db/system/config", $config:data-root),
+xdb:create-collection("/", $config:corpora-root),
+xdb:create-collection("/", $config:webhook-root),
+local:mkcol("/db/system/config", $config:corpora-root),
 xdb:store-files-from-pattern(
-  concat("/db/system/config", $config:data-root), $dir, "data.xconf"
-),
-xdb:create-collection("/", $config:rdf-root),
-xdb:create-collection("/", $config:metrics-root),
-xdb:create-collection("/", $config:sitelinks-root),
-xdb:create-collection("/", $config:webhook-root)
+  concat("/db/system/config", $config:corpora-root), $dir, "data.xconf"
+)

--- a/speakers.xq
+++ b/speakers.xq
@@ -12,6 +12,9 @@ xquery version "3.1";
  : curl http://localhost:8080/exist/rest/db/apps/dracor-v1/speakers.xq?id=ep000148
  :)
 
+import module namespace config = "http://dracor.org/ns/exist/v1/config"
+  at "modules/config.xqm";
+
 declare namespace tei = "http://www.tei-c.org/ns/1.0";
 declare namespace ep = "http://earlyprint.org/ns/1.0";
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
@@ -19,7 +22,7 @@ declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare option output:method "json";
 declare option output:media-type "application/json";
 
-let $col := request:get-parameter("collection", "/db/data/dracor/tei")
+let $col := request:get-parameter("collection", $config:corpora-root)
 let $id := request:get-parameter("id", "")
 
 return if (not($id)) then (


### PR DESCRIPTION
The new structure puts all files (tei, rdf, metrics, sitelinks) for an individual play into a single collection instead of spreading them over different type specific collections with sub paths for each corpus. This makes it much easier to delete a single play or an entire corpus since we no longer need to do housekeeping in several collections with a delete trigger.

The new structure looks similar to this:

```
    db
    |- dracor
      |- corpora
        |- ger
        | |- lessing-emilia-galotti
        | | |- tei.xml
        | | |- metrics.xml
        | | |- rdf.xml
        | | |- sitelinks.xml
        | |- zschokke-abellino
        |   |- ...
        |- als
        |- ita
        |- ...
```