### PR TITLE
Refine OpenAPI spec schemas

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -1061,7 +1061,7 @@ paths:
                   "totalChildren" : 1,
                   "title" : "Test Drama Corpus",
                   "description" : "This corpus is for testing purposes only. It features a handful of plays in different languages.",
-                  "members" : [ 
+                  "members" : [
                   {
                     "@id" : "http://localhost:8088/id/test000001",
                     "@type" : "Resource",
@@ -1069,8 +1069,8 @@ paths:
                     "totalItems" : 0,
                     "totalParents" : 1,
                     "totalChildren" : 0,
-                    "dublinCore" : 
-                      { 
+                    "dublinCore" :
+                      {
                         "language" : "rus",
                         "creator" : "Гоголь, Николай Васильевич"
                       },
@@ -1084,7 +1084,7 @@ paths:
           description: Bad request. Using the parameter `page` with a document is not possible. (Paging functionality has not been implemented yet.)
         '404':
           description: The requested resource is not available.
-        '501': 
+        '501':
           description: Not implemented. Using the undocumented parameter `page` will result in this status code. The paging functionality has not been implemented yet.
 
   /dts/navigation:
@@ -1098,7 +1098,7 @@ paths:
         - name: resource
           in: query
           required: true
-          description: The unique identifier for the Resource whose tree or subtree must be returned. Should be the full URI of a play (recommended) or the DraCor ID. 
+          description: The unique identifier for the Resource whose tree or subtree must be returned. Should be the full URI of a play (recommended) or the DraCor ID.
           schema:
             type: string
           example: https://dracor.org/id/ger000088
@@ -1153,8 +1153,8 @@ paths:
         '404':
           description: There are no Citeable Unit(s) identified by the provided identifier(s) in `ref`, `start` or `end`.
         '501':
-          description: Not implemented. Not all of the functionality foreseen by the specification is fully implemented, e.g. requesting sub-structures of non-body elements. 
-  
+          description: Not implemented. Not all of the functionality foreseen by the specification is fully implemented, e.g. requesting sub-structures of non-body elements.
+
   /dts/document:
     get:
       summary: DTS Document endpoint
@@ -1166,7 +1166,7 @@ paths:
         - name: resource
           in: query
           required: true
-          description: The unique identifier for the Resource whose tree or subtree must be returned. Should be the full URI of a play (recommended) or the DraCor ID. 
+          description: The unique identifier for the Resource whose tree or subtree must be returned. Should be the full URI of a play (recommended) or the DraCor ID.
           schema:
             type: string
           example: https://dracor.org/id/ger000088
@@ -1393,12 +1393,16 @@ components:
       type: object
       properties:
         name:
+          description: https://dracor.org/ontology/dracor-api-ontology#service_name
           type: string
         version:
+          description: https://dracor.org/ontology/dracor-api-ontology#service_version
           type: string
         status:
+          description: https://dracor.org/ontology/dracor-api-ontology#service_development_stage
           type: string
         existdb:
+          description: https://dracor.org/ontology/dracor-api-ontology#service_dependency_is_existdb_version
           type: string
         base:
           type: string
@@ -1406,280 +1410,490 @@ components:
         openapi:
           type: string
           format: url
+      required:
+        - name
+        - version
+        - status
+        - existdb
+        - base
+        - openapi
     WordCounts:
       type: object
       properties:
         text:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_word_tokens_in_text_elements
           type: integer
         stage:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_word_tokens_in_stage
           type: integer
         sp:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_word_tokens_in_sp
           type: integer
+      required:
+        - text
+        - stage
+        - sp
     CorpusMetrics:
       type: object
       properties:
         characters:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_characters
           type: integer
         stage:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_stage
           type: integer
         updated:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_metrics_date_updated
           type: string
         sp:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_sp
           type: integer
         text:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_tei_text_elements
           type: integer
         plays:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_plays
           type: integer
         wordcount:
+          description: https://dracor.org/ontology/dracor-api-ontology#contains_corpus_wordcount_data
           $ref: '#/components/schemas/WordCounts'
         male:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_characters_male
           type: integer
         female:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_characters_female
           type: integer
+      required:
+        - characters
+        - stage
+        - updated
+        - sp
+        - text
+        - plays
+        - wordcount
+        - male
+        - female
     CorpusInCorpora:
       type: object
       required:
-        - name
+        - acronym
         - title
+        - licence
+        - licenceUrl
         - uri
+        - description
+        - name
+        - repository
       properties:
         acronym:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_acronym
           type: string
         commit:
           type: string
         metrics:
+          description: contains_corpus_metrics_data
           $ref: '#/components/schemas/CorpusMetrics'
         title:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_title
           type: string
         licence:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_licence
           type: string
         licenceUrl:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_licence_url
           type: string
           format: url
         uri:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_uri
           type: string
           format: url
         description:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_description
           type: string
         name:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_name
           type: string
         repository:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_repository
           type: string
           format: url
     SourceInPlayMetadata:
       type: object
       properties:
         url:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_digital_source_url
+          type: string
+          format: url
           nullable: true
         name:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_digital_source_name
           type: string
           nullable: true
+      required:
+        - url
+        - name
     ExternalReferenceResourceId:
       type: object
       properties:
         type:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_ref_external_id
           type: string
         ref:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_ref_type
           type: string
+      required:
+        - type
+        - ref
     AuthorInPlayInCorpus:
       type: object
       properties:
         refs:
+          description: https://dracor.org/ontology/dracor-api-ontology#contains_external_ref_id_data
           type: array
           items:
             $ref: '#/components/schemas/ExternalReferenceResourceId'
         alsoKnownAs:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_also_known_as
           type: array
           items:
             type: string
         fullnameEn:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_fullname_en
           type: string
         name:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_name
           type: string
         shortnameEn:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_shortname
           type: string
         nameEn:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_name_en
           type: string
         fullname:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_fullname
           type: string
         shortname:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_shortname
           type: string
+      required:
+        - refs
+        - alsoKnownAs
+        - fullnameEn
+        - name
+        - shortnameEn
+        - nameEn
+        - fullname
+        - shortname
     PlayInCorpus:
       type: object
       properties:
         wikidataId:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_wikidata_id
           type: string
           nullable: true
         yearWritten:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_written
           type: string
           nullable: true
         source:
+          description: https://dracor.org/ontology/dracor-api-ontology#contains_digital_source_data
           $ref: '#/components/schemas/SourceInPlayMetadata'
         yearPremiered:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_premiered
           type: string
           nullable: true
         title:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_title
           type: string
         networkdataCsvUrl:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_data_csv_url
           type: string
           format: url
         id:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_id
           type: string
         titleEn:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_title_en
           type: string
         subtitle:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_subtitle
           type: string
         datePremiered:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_date_premiered
           type: string
         yearPrinted:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_printed
           type: string
           nullable: true
         yearNormalized:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_normalized
           type: integer
           nullable: true
         authors:
+          description: https://dracor.org/ontology/dracor-api-ontology#contains_play_author_data
           type: array
           items:
             $ref: '#/components/schemas/AuthorInPlayInCorpus'
         name:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_name
           type: string
         networkSize:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_size
           type: integer
         subtitleEn:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_subtitle_en
           type: string
+      required:
+        - wikidataId
+        - yearWritten
+        - source
+        - yearPremiered
+        - title
+        - networkdataCsvUrl
+        - id
+        - titleEn
+        - subtitle
+        - datePremiered
+        - yearPrinted
+        - yearNormalized
+        - authors
+        - name
+        - networkSize
+        - subtitleEn
     Corpus:
       type: object
       required:
-        - name
+        - acronym
         - title
+        - licence
+        - licenceUrl
+        - description
+        - name
+        - plays
+        - repository
       properties:
         acronym:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_acronym
           type: string
         commit:
           type: string
         title:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_title
           type: string
         licence:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_licence
           type: string
         licenceUrl:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_licence_url
           type: string
           format: url
         description:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_description
           type: string
         name:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_name
           type: string
         plays:
+          description: https://dracor.org/ontology/dracor-api-ontology#contains_play_data
           type: array
           items:
             $ref: '#/components/schemas/PlayInCorpus'
         repository:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_repository
           type: string
           format: url
     PlayMetadata:
       type: object
       properties:
         numOfSpeakersMale:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_speakers_gender_male
           type: integer
         diameter:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_diameter
           type: integer
         wikidataId:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_wikidata_id
           type: string
           nullable: true
         numOfSpeakersFemale:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_speakers_gender_female
           type: integer
         averageClustering:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_clustering
           type: number
         yearPremiered:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_premiered
           type: string
           nullable: true
         originalSourcePubPlace:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_original_source_publication_place
           type: string
           nullable: true
         numOfSpeakers:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_speakers
           type: integer
         name:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_name
           type: string
         wordCountStage:
+          description: https://dracor.org/ontology/dracor-api-ontology#pplay_num_of_word_tokens_in_stage
           type: integer
         normalizedGenre:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_genre_normalized
           type: string
           nullable: true
         numOfL:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_verse_lines
           type: integer
         wordCountSp:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_word_tokens_in_sp
           type: integer
         numOfSpeakersUnknown:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_speakers_gender_unknown
           type: integer
         averagePathLength:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_path_length
           type: number
         originalSourceYear:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_original_source_publication_year
           type: integer
           nullable: true
         maxDegree:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_max_degree
           type: integer
         numEdges:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_num_edges
           type: integer
         subtitle:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_subtitle
           type: string
           nullable: true
         firstAuthor:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_first_author_shortname
           type: string
         originalSourcePublisher:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_original_source_publisher
           type: string
           nullable: true
         libretto:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_is_libretto
           type: boolean
         numConnectedComponents:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_num_connected_components
           type: integer
         yearWritten:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_written
           type: string
           nullable: true
         playName:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_name
           type: string
         numOfP:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_paragraphs
           type: integer
         id:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_id
           type: string
         wordCountText:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_word_tokens_in_text_elements
           type: integer
         datePremiered:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_date_premiered
           type: string
         size:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_size
           type: integer
         averageDegree:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_degree
           type: number
         yearPrinted:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_printed
           type: string
           nullable: true
         numOfSegments:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_segments
           type: integer
         numOfActs:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_acts
           type: integer
         title:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_title
           type: string
         wikipediaLinkCount:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_wikipedia_links
           type: integer
           nullable: true
         digitalSource:
           nullable: true
         numOfPersonGroups:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_person_groups
           type: integer
         yearNormalized:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_normalized
           type: integer
           nullable: true
         numOfCoAuthors:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_co_authors
           type: integer
         maxDegreeIds:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_max_degree_character_id
           type: string
         originalSourceNumberOfPages:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_original_source_num_of_pages
           type: integer
           nullable: true
         density:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_density
           type: number
+      required:
+        - numOfSpeakersMale
+        - diameter
+        - wikidataId
+        - numOfSpeakersFemale
+        - averageClustering
+        - yearPremiered
+        - originalSourcePubPlace
+        - numOfSpeakers
+        - name
+        - wordCountStage
+        - normalizedGenre
+        - numOfL
+        - wordCountSp
+        - numOfSpeakersUnknown
+        - averagePathLength
+        - originalSourceYear
+        - maxDegree
+        - numEdges
+        - subtitle
+        - firstAuthor
+        - originalSourcePublisher
+        - libretto
+        - numConnectedComponents
+        - yearWritten
+        - playName
+        - numOfP
+        - id
+        - wordCountText
+        - datePremiered
+        - size
+        - averageDegree
+        - yearPrinted
+        - numOfSegments
+        - numOfActs
+        - title
+        - wikipediaLinkCount
+        - digitalSource
+        - numOfPersonGroups
+        - yearNormalized
+        - numOfCoAuthors
+        - maxDegreeIds
+        - originalSourceNumberOfPages
+        - density
     SegmentItemInPlayMetadata:
       type: object
       properties:
         type:
+          description: https://dracor.org/ontology/dracor-api-ontology#segment_type
           type: string
           nullable: true
         speakers:
@@ -1687,9 +1901,16 @@ components:
           items:
             type: string
         number:
+          description: https://dracor.org/ontology/dracor-api-ontology#segment_number
           type: integer
         title:
+          description: https://dracor.org/ontology/dracor-api-ontology#segment_title
           type: string
+      required:
+        - type
+        - speakers
+        - number
+        - title
     AuthorInPlayMetadata:
       type: object
       properties:
@@ -1698,46 +1919,75 @@ components:
           items:
             $ref: '#/components/schemas/ExternalReferenceResourceId'
         alsoKnownAs:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_also_known_as
           type: array
           items:
             type: string
         fullnameEn:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_fullname_en
           type: string
         name:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_name
           type: string
         shortnameEn:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_shortname_en
           type: string
         nameEn:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_name_en
           type: string
         fullname:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_fullname
           type: string
         shortname:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_shortname
           type: string
+      required:
+        - refs
+        - alsoKnownAs
+        - fullnameEn
+        - name
+        - shortnameEn
+        - nameEn
+        - fullname
+        - shortname
     CharacterInPlayMetadata:
       type: object
       properties:
         wikidataId:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_wikidata_id
           type: string
         id:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_id
           type: string
         isGroup:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_is_group
           type: boolean
         name:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_name
           type: string
           nullable: true
         sex:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_gender
           type: string
           enum:
           - MALE
           - FEMALE
           - UNKNOWN
           nullable: true
+      required:
+        - wikidataId
+        - id
+        - isGroup
+        - name
+        - sex
     RelationItemInPlayMetadata:
       type: object
       properties:
         directed:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_relation_is_directed
           type: boolean
         type:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_relation_type
           type: string
           enum:
           - parent_of
@@ -1748,9 +1998,16 @@ components:
           - spouses
           - friends
         source:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_relation_from
           type: string
         target:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_relation_to
           type: string
+      required:
+        - directed
+        - type
+        - source
+        - target
     Play:
       type: object
       required:
@@ -1758,6 +2015,7 @@ components:
         - name
         - corpus
         - title
+        - titleEn
         - authors
         - characters
         - segments
@@ -1765,8 +2023,22 @@ components:
         - allInSegment
         - libretto
         - uri
+        - wikidataId
+        - yearPremiered
+        - allInIndex
+        - normalizedGenre
+        - subtitleEn
+        - source
+        - subtitle
+        - allInSegment
+        - yearWritten
+        - datePremiered
+        - yearPrinted
+        - relations
+        - originalSource
       properties:
         wikidataId:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_wikidata_id
           type: string
           nullable: true
         segments:
@@ -1774,170 +2046,261 @@ components:
           items:
             $ref: '#/components/schemas/SegmentItemInPlayMetadata'
         corpus:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_corpus_name
           type: string
         yearPremiered:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_premiered
           type: string
           nullable: true
         allInIndex:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_all_in_index
           type: number
           nullable: true
           minimum: 0.0
           maximum: 1.0
         titleEn:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_title_en
           type: string
         authors:
+          description: https://dracor.org/ontology/dracor-api-ontology#contains_play_author_data
           type: array
           items:
             $ref: '#/components/schemas/AuthorInPlayMetadata'
         name:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_name
           type: string
         normalizedGenre:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_genre_normalized
           type: string
           nullable: true
         subtitleEn:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_subtitle_en
           type: string
         characters:
+          description: https://dracor.org/ontology/dracor-api-ontology#contains_play_character_data
           type: array
           items:
             $ref: '#/components/schemas/CharacterInPlayMetadata'
         source:
+          description: https://dracor.org/ontology/dracor-api-ontology#ccontains_digital_source_data
           $ref: '#/components/schemas/SourceInPlayMetadata'
         subtitle:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_subtitle
           type: string
           nullable: true
         libretto:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_is_libretto
           type: boolean
         allInSegment:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_all_in_segment
           type: integer
           nullable: true
         yearWritten:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_written
           type: string
           nullable: true
         id:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_id
           type: string
         datePremiered:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_date_premiered
           type: string
         yearPrinted:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_printed
           type: string
           nullable: true
         relations:
+          description: https://dracor.org/ontology/dracor-api-ontology#contains_character_relation_data
           type: array
           items:
             $ref: '#/components/schemas/RelationItemInPlayMetadata'
         title:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_title
           type: string
         yearNormalized:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_normalized
           type: integer
           nullable: true
         originalSource:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_original_source_full_citation
           type: string
-        uri:
-          type: string
-          format: url
     NodeInPlayMetrics:
       type: object
       properties:
         closeness:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_node_closeness
           type: number
         betweenness:
+          description: https://dracor.org/ontology/dracor-api-ontology#haracter_node_betweenness
           type: number
         degree:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_node_degree
           type: integer
         weightedDegree:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_node_weighted_degree
           type: integer
         id:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_id
           type: string
         eigenvector:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_node_eigenvector
           type: number
+      required:
+        - closeness
+        - betweenness
+        - degree
+        - weightedDegree
+        - id
+        - eigenvector
     PlayMetrics:
       type: object
       properties:
         averagePathLength:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_path_length
           type: number
         diameter:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_diameter
           type: integer
         nodes:
           type: array
           items:
             $ref: '#/components/schemas/NodeInPlayMetrics'
         corpus:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_corpus_name
           type: string
         averageClustering:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_clustering
           type: number
         maxDegree:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_degree
           type: integer
         wikipediaLinkCount:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_wikipedia_links
           type: integer
           nullable: true
         id:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_id
           type: string
         numEdges:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_num_edges
           type: integer
         size:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_size
           type: integer
         averageDegree:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_degree
           type: number
         name:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_name
           type: string
         maxDegreeIds:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_max_degree_character_id
           type: array
           items:
             type: string
         numConnectedComponents:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_num_connected_components
           type: integer
         density:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_density
           type: number
+      required:
+        - averagePathLength
+        - diameter
+        - nodes
+        - corpus
+        - averageClustering
+        - maxDegree
+        - wikipediaLinkCount
+        - id
+        - numEdges
+        - size
+        - averageDegree
+        - name
+        - maxDegreeIds
+        - numConnectedComponents
+        - density
     Character:
       type: object
       properties:
         closeness:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_node_closeness
           type: number
           nullable: true
         wikidataId:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_wikidata_id
           type: string
         betweenness:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_node_betweenness
           type: number
           nullable: true
         degree:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_node_degree
           type: integer
           nullable: true
         weightedDegree:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_node_weighted_degree
           type: integer
           nullable: true
         numOfSpeechActs:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_num_of_sp
           type: integer
         id:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_id
           type: string
         eigenvector:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_node_eigenvector
           type: number
           nullable: true
         numOfScenes:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_num_of_segments
           type: integer
         numOfWords:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_num_of_word_tokens
           type: integer
         isGroup:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_is_group
           type: boolean
         name:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_name
           type: string
           nullable: true
         gender:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_gender
           type: string
           enum:
           - MALE
           - FEMALE
           - UNKNOWN
           nullable: true
+      required:
+        - closeness
+        - wikidataId
+        - betweenness
+        - degree
+        - weightedDegree
+        - numOfSpeechActs
+        - id
+        - eigenvector
+        - numOfScenes
+        - numOfWords
+        - isGroup
+        - name
+        - gender
     SpokenTextByCharacter:
       type: object
       properties:
         roles:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_role
           type: array
           nullable: true
           items:
             type: string
         id:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_id
           type: string
         isGroup:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_is_group
           type: boolean
         gender:
           type: string
@@ -1947,11 +2310,20 @@ components:
           - UNKNOWN
           nullable: true
         label:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_name
           type: string
         text:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_spoken_text
           type: array
           items:
             type: string
+      required:
+        - roles
+        - id
+        - isGroup
+        - gender
+        - label
+        - text
     PlayWithWikidataCharacter:
       type: object
       properties:

--- a/api.yaml
+++ b/api.yaml
@@ -1475,15 +1475,6 @@ components:
         - female
     CorpusInCorpora:
       type: object
-      required:
-        - acronym
-        - title
-        - licence
-        - licenceUrl
-        - uri
-        - description
-        - name
-        - repository
       properties:
         acronym:
           description: https://dracor.org/ontology/dracor-api-ontology#corpus_acronym
@@ -1517,7 +1508,13 @@ components:
           description: https://dracor.org/ontology/dracor-api-ontology#corpus_repository
           type: string
           format: url
+      required:
+        - name
+        - title
+        - acronym
+        - uri
     SourceInPlayMetadata:
+      # see dutil:get-source
       type: object
       properties:
         url:
@@ -1529,10 +1526,11 @@ components:
           description: https://dracor.org/ontology/dracor-api-ontology#play_digital_source_name
           type: string
           nullable: true
-      required:
-        - url
-        - name
+      # currently neither name nor url is required, but we omit the source
+      # object if none of the properties is available
+      required: []
     ExternalReferenceResourceId:
+      # see dutil:get-authors
       type: object
       properties:
         type:
@@ -1545,6 +1543,7 @@ components:
         - type
         - ref
     AuthorInPlayInCorpus:
+      # see dutil:get-authors
       type: object
       properties:
         refs:
@@ -1576,17 +1575,17 @@ components:
           description: https://dracor.org/ontology/dracor-api-ontology#play_author_shortname
           type: string
       required:
-        - refs
-        - alsoKnownAs
-        - fullnameEn
         - name
-        - shortnameEn
-        - nameEn
         - fullname
         - shortname
+        - refs
     PlayInCorpus:
+      # see api:corpus-index
       type: object
       properties:
+        uri:
+          type: string
+          format: url
         wikidataId:
           description: https://dracor.org/ontology/dracor-api-ontology#play_wikidata_id
           type: string
@@ -1644,33 +1643,21 @@ components:
           description: https://dracor.org/ontology/dracor-api-ontology#play_subtitle_en
           type: string
       required:
-        - wikidataId
-        - yearWritten
-        - source
-        - yearPremiered
-        - title
-        - networkdataCsvUrl
         - id
-        - titleEn
-        - subtitle
-        - datePremiered
-        - yearPrinted
-        - yearNormalized
-        - authors
+        - uri
         - name
-        - networkSize
-        - subtitleEn
-    Corpus:
-      type: object
-      required:
-        - acronym
         - title
-        - licence
-        - licenceUrl
-        - description
-        - name
-        - plays
-        - repository
+        - authors
+        - yearNormalized
+        - yearPremiered
+        - yearPrinted
+        - yearWritten
+        - networkSize
+        - networkdataCsvUrl
+        - wikidataId
+    Corpus:
+      # see dutil:get-corpus-info
+      type: object
       properties:
         acronym:
           description: https://dracor.org/ontology/dracor-api-ontology#corpus_acronym
@@ -1702,7 +1689,12 @@ components:
           description: https://dracor.org/ontology/dracor-api-ontology#corpus_repository
           type: string
           format: url
+      required:
+        - name
+        - title
+        - acronym
     PlayMetadata:
+      # see dutil:get-corpus-meta-data
       type: object
       properties:
         numOfSpeakersMale:
@@ -1785,9 +1777,6 @@ components:
           description: https://dracor.org/ontology/dracor-api-ontology#play_year_written
           type: string
           nullable: true
-        playName:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_name
-          type: string
         numOfP:
           description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_paragraphs
           type: integer
@@ -1846,50 +1835,50 @@ components:
           description: https://dracor.org/ontology/dracor-api-ontology#play_network_density
           type: number
       required:
-        - numOfSpeakersMale
-        - diameter
-        - wikidataId
-        - numOfSpeakersFemale
-        - averageClustering
-        - yearPremiered
-        - originalSourcePubPlace
-        - numOfSpeakers
-        - name
-        - wordCountStage
-        - normalizedGenre
-        - numOfL
-        - wordCountSp
-        - numOfSpeakersUnknown
-        - averagePathLength
-        - originalSourceYear
-        - maxDegree
-        - numEdges
-        - subtitle
-        - firstAuthor
-        - originalSourcePublisher
-        - libretto
-        - numConnectedComponents
-        - yearWritten
-        - playName
-        - numOfP
         - id
-        - wordCountText
-        - datePremiered
-        - size
-        - averageDegree
-        - yearPrinted
-        - numOfSegments
-        - numOfActs
+        - name
         - title
-        - wikipediaLinkCount
-        - digitalSource
-        - numOfPersonGroups
+        - subtitle
+        - wikidataId
+        - firstAuthor
         - yearNormalized
-        - numOfCoAuthors
-        - maxDegreeIds
-        - originalSourceNumberOfPages
+        - yearPremiered
+        - yearPrinted
+        - yearWritten
+        - datePremiered
+        - digitalSource
+        - libretto
+        - averageClustering
+        - averageDegree
+        - averagePathLength
         - density
+        - diameter
+        - maxDegree
+        - maxDegreeIds
+        - normalizedGenre
+        - numConnectedComponents
+        - numEdges
+        - numOfActs
+        - numOfCoAuthors
+        - numOfL
+        - numOfP
+        - numOfPersonGroups
+        - numOfSegments
+        - numOfSpeakers
+        - numOfSpeakersFemale
+        - numOfSpeakersMale
+        - numOfSpeakersUnknown
+        - originalSourceNumberOfPages
+        - originalSourcePublisher
+        - originalSourcePubPlace
+        - originalSourceYear
+        - size
+        - wikipediaLinkCount
+        - wordCountSp
+        - wordCountStage
+        - wordCountText
     SegmentItemInPlayMetadata:
+      # see dutil:get-play-info
       type: object
       properties:
         type:
@@ -1908,10 +1897,10 @@ components:
           type: string
       required:
         - type
-        - speakers
         - number
-        - title
     AuthorInPlayMetadata:
+      # FIXME: this schema seems to be identical to AuthorInPlayInCorpus, can we
+      # eliminate it?
       type: object
       properties:
         refs:
@@ -1942,15 +1931,12 @@ components:
           description: https://dracor.org/ontology/dracor-api-ontology#play_author_shortname
           type: string
       required:
-        - refs
-        - alsoKnownAs
-        - fullnameEn
         - name
-        - shortnameEn
-        - nameEn
         - fullname
         - shortname
+        - refs
     CharacterInPlayMetadata:
+      # see dutil:get-play-info
       type: object
       properties:
         wikidataId:
@@ -1969,18 +1955,18 @@ components:
         sex:
           description: https://dracor.org/ontology/dracor-api-ontology#character_gender
           type: string
-          enum:
-          - MALE
-          - FEMALE
-          - UNKNOWN
           nullable: true
+          enum:
+            - MALE
+            - FEMALE
+            - UNKNOWN
       required:
-        - wikidataId
         - id
-        - isGroup
         - name
+        - isGroup
         - sex
     RelationItemInPlayMetadata:
+      # see dutil:get-relations
       type: object
       properties:
         directed:
@@ -2009,33 +1995,8 @@ components:
         - source
         - target
     Play:
+      # see dutil:get-play-info
       type: object
-      required:
-        - id
-        - name
-        - corpus
-        - title
-        - titleEn
-        - authors
-        - characters
-        - segments
-        - yearNormalized
-        - allInSegment
-        - libretto
-        - uri
-        - wikidataId
-        - yearPremiered
-        - allInIndex
-        - normalizedGenre
-        - subtitleEn
-        - source
-        - subtitle
-        - allInSegment
-        - yearWritten
-        - datePremiered
-        - yearPrinted
-        - relations
-        - originalSource
       properties:
         wikidataId:
           description: https://dracor.org/ontology/dracor-api-ontology#play_wikidata_id
@@ -2124,7 +2085,25 @@ components:
         originalSource:
           description: https://dracor.org/ontology/dracor-api-ontology#play_original_source_full_citation
           type: string
+      required:
+        - id
+        - uri
+        - name
+        - corpus
+        - title
+        - authors
+        - normalizedGenre
+        - libretto
+        - allInSegment
+        - allInIndex
+        - characters
+        - segments
+        - yearPremiered
+        - yearPrinted
+        - yearWritten
+        - yearNormalized
     NodeInPlayMetrics:
+      # see dutil:get-play-metrics
       type: object
       properties:
         closeness:
@@ -2146,13 +2125,14 @@ components:
           description: https://dracor.org/ontology/dracor-api-ontology#character_node_eigenvector
           type: number
       required:
-        - closeness
-        - betweenness
-        - degree
-        - weightedDegree
         - id
+        - betweenness
+        - closeness
+        - degree
         - eigenvector
+        - weightedDegree
     PlayMetrics:
+      # see dutil:get-play-metrics
       type: object
       properties:
         averagePathLength:
@@ -2205,18 +2185,18 @@ components:
           description: https://dracor.org/ontology/dracor-api-ontology#play_network_density
           type: number
       required:
+        - id
+        - name
+        - corpus
+        - nodes
+        - wikipediaLinkCount
         - averagePathLength
         - diameter
-        - nodes
-        - corpus
         - averageClustering
         - maxDegree
-        - wikipediaLinkCount
-        - id
         - numEdges
         - size
         - averageDegree
-        - name
         - maxDegreeIds
         - numConnectedComponents
         - density
@@ -2274,20 +2254,20 @@ components:
           - UNKNOWN
           nullable: true
       required:
-        - closeness
-        - wikidataId
-        - betweenness
+        - id
+        - name
+        - isGroup
+        - gender
+        - numOfScenes
+        - numOfSpeechActs
+        - numOfWords
         - degree
         - weightedDegree
-        - numOfSpeechActs
-        - id
+        - closeness
+        - betweenness
         - eigenvector
-        - numOfScenes
-        - numOfWords
-        - isGroup
-        - name
-        - gender
     SpokenTextByCharacter:
+      # see api:get-spoken-text-by-character
       type: object
       properties:
         roles:
@@ -2318,13 +2298,14 @@ components:
           items:
             type: string
       required:
-        - roles
         - id
+        - label
         - isGroup
         - gender
-        - label
+        - roles
         - text
     PlayWithWikidataCharacter:
+      # see dutil:get-plays-with-character
       type: object
       properties:
         characterName:
@@ -2340,7 +2321,14 @@ components:
           type: array
           items:
             type: string
+      required:
+        - id
+        - uri
+        - title
+        - authors
+        - characterName
     DtsEntrypoint:
+      # see ddts:entry-point
       type: object
       properties:
         "@context":
@@ -2357,3 +2345,11 @@ components:
           type: string
         navigation:
           type: string
+      required:
+        - "@context"
+        - "@id"
+        - "@type"
+        - dtsVersion
+        - collection
+        - document
+        - navigation

--- a/api.yaml
+++ b/api.yaml
@@ -1439,12 +1439,15 @@ components:
         characters:
           description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_characters
           type: integer
+        male:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_characters_male
+          type: integer
+        female:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_characters_female
+          type: integer
         stage:
           description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_stage
           type: integer
-        updated:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_metrics_date_updated
-          type: string
         sp:
           description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_sp
           type: integer
@@ -1457,35 +1460,39 @@ components:
         wordcount:
           description: https://dracor.org/ontology/dracor-api-ontology#contains_corpus_wordcount_data
           $ref: '#/components/schemas/WordCounts'
-        male:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_characters_male
-          type: integer
-        female:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_characters_female
-          type: integer
+        updated:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_metrics_date_updated
+          type: string
       required:
         - characters
+        - male
+        - female
         - stage
-        - updated
         - sp
         - text
         - plays
         - wordcount
-        - male
-        - female
+        - updated
     CorpusInCorpora:
       type: object
       properties:
+        uri:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_uri
+          type: string
+          format: url
+        name:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_name
+          type: string
+        title:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_title
+          type: string
         acronym:
           description: https://dracor.org/ontology/dracor-api-ontology#corpus_acronym
           type: string
         commit:
           type: string
-        metrics:
-          description: contains_corpus_metrics_data
-          $ref: '#/components/schemas/CorpusMetrics'
-        title:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_title
+        description:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_description
           type: string
         licence:
           description: https://dracor.org/ontology/dracor-api-ontology#corpus_licence
@@ -1494,37 +1501,30 @@ components:
           description: https://dracor.org/ontology/dracor-api-ontology#corpus_licence_url
           type: string
           format: url
-        uri:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_uri
-          type: string
-          format: url
-        description:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_description
-          type: string
-        name:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_name
-          type: string
         repository:
           description: https://dracor.org/ontology/dracor-api-ontology#corpus_repository
           type: string
           format: url
+        metrics:
+          # ontology: contains_corpus_metrics_data
+          $ref: '#/components/schemas/CorpusMetrics'
       required:
+        - uri
         - name
         - title
         - acronym
-        - uri
     SourceInPlayMetadata:
       # see dutil:get-source
       type: object
       properties:
+        name:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_digital_source_name
+          type: string
+          nullable: true
         url:
           description: https://dracor.org/ontology/dracor-api-ontology#play_digital_source_url
           type: string
           format: url
-          nullable: true
-        name:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_digital_source_name
-          type: string
           nullable: true
       # currently neither name nor url is required, but we omit the source
       # object if none of the properties is available
@@ -1546,6 +1546,15 @@ components:
       # see dutil:get-authors
       type: object
       properties:
+        name:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_name
+          type: string
+        fullname:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_fullname
+          type: string
+        shortname:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_shortname
+          type: string
         refs:
           description: https://dracor.org/ontology/dracor-api-ontology#contains_external_ref_id_data
           type: array
@@ -1556,23 +1565,14 @@ components:
           type: array
           items:
             type: string
-        fullnameEn:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_fullname_en
-          type: string
-        name:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_name
-          type: string
-        shortnameEn:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_shortname
-          type: string
         nameEn:
           description: https://dracor.org/ontology/dracor-api-ontology#play_author_name_en
           type: string
-        fullname:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_fullname
+        fullnameEn:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_fullname_en
           type: string
-        shortname:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_shortname
+        shortnameEn:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_author_shortname_en
           type: string
       required:
         - name
@@ -1583,65 +1583,65 @@ components:
       # see api:corpus-index
       type: object
       properties:
-        uri:
-          type: string
-          format: url
-        wikidataId:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_wikidata_id
-          type: string
-          nullable: true
-        yearWritten:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_written
-          type: string
-          nullable: true
-        source:
-          description: https://dracor.org/ontology/dracor-api-ontology#contains_digital_source_data
-          $ref: '#/components/schemas/SourceInPlayMetadata'
-        yearPremiered:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_premiered
-          type: string
-          nullable: true
-        title:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_title
-          type: string
-        networkdataCsvUrl:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_data_csv_url
-          type: string
-          format: url
         id:
           description: https://dracor.org/ontology/dracor-api-ontology#play_id
           type: string
-        titleEn:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_title_en
+        uri:
+          type: string
+          format: url
+        name:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_name
+          type: string
+        title:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_title
           type: string
         subtitle:
           description: https://dracor.org/ontology/dracor-api-ontology#play_subtitle
           type: string
-        datePremiered:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_date_premiered
+        titleEn:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_title_en
           type: string
-        yearPrinted:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_printed
+        subtitleEn:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_subtitle_en
           type: string
-          nullable: true
-        yearNormalized:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_normalized
-          type: integer
-          nullable: true
         authors:
           description: https://dracor.org/ontology/dracor-api-ontology#contains_play_author_data
           type: array
           items:
             $ref: '#/components/schemas/AuthorInPlayInCorpus'
-        name:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_name
+        yearNormalized:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_normalized
+          type: integer
+          nullable: true
+        yearWritten:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_written
           type: string
+          nullable: true
+        yearPremiered:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_premiered
+          type: string
+          nullable: true
+        yearPrinted:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_printed
+          type: string
+          nullable: true
+        datePremiered:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_date_premiered
+          type: string
+        source:
+          description: https://dracor.org/ontology/dracor-api-ontology#contains_digital_source_data
+          $ref: '#/components/schemas/SourceInPlayMetadata'
+        networkdataCsvUrl:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_data_csv_url
+          type: string
+          format: url
         networkSize:
           description: https://dracor.org/ontology/dracor-api-ontology#play_network_size
           type: integer
-        subtitleEn:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_subtitle_en
+        wikidataId:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_wikidata_id
           type: string
+          nullable: true
       required:
         - id
         - uri
@@ -1649,9 +1649,9 @@ components:
         - title
         - authors
         - yearNormalized
+        - yearWritten
         - yearPremiered
         - yearPrinted
-        - yearWritten
         - networkSize
         - networkdataCsvUrl
         - wikidataId
@@ -1659,14 +1659,24 @@ components:
       # see dutil:get-corpus-info
       type: object
       properties:
-        acronym:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_acronym
-          type: string
-        commit:
+        name:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_name
           type: string
         title:
           description: https://dracor.org/ontology/dracor-api-ontology#corpus_title
           type: string
+        acronym:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_acronym
+          type: string
+        description:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_description
+          type: string
+        commit:
+          type: string
+        repository:
+          description: https://dracor.org/ontology/dracor-api-ontology#corpus_repository
+          type: string
+          format: url
         licence:
           description: https://dracor.org/ontology/dracor-api-ontology#corpus_licence
           type: string
@@ -1674,21 +1684,11 @@ components:
           description: https://dracor.org/ontology/dracor-api-ontology#corpus_licence_url
           type: string
           format: url
-        description:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_description
-          type: string
-        name:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_name
-          type: string
         plays:
           description: https://dracor.org/ontology/dracor-api-ontology#contains_play_data
           type: array
           items:
             $ref: '#/components/schemas/PlayInCorpus'
-        repository:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_repository
-          type: string
-          format: url
       required:
         - name
         - title
@@ -1697,143 +1697,143 @@ components:
       # see dutil:get-corpus-meta-data
       type: object
       properties:
-        numOfSpeakersMale:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_speakers_gender_male
-          type: integer
-        diameter:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_diameter
-          type: integer
-        wikidataId:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_wikidata_id
+        id:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_id
           type: string
-          nullable: true
-        numOfSpeakersFemale:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_speakers_gender_female
-          type: integer
-        averageClustering:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_clustering
-          type: number
-        yearPremiered:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_premiered
-          type: string
-          nullable: true
-        originalSourcePubPlace:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_original_source_publication_place
-          type: string
-          nullable: true
-        numOfSpeakers:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_speakers
-          type: integer
         name:
           description: https://dracor.org/ontology/dracor-api-ontology#play_name
           type: string
-        wordCountStage:
-          description: https://dracor.org/ontology/dracor-api-ontology#pplay_num_of_word_tokens_in_stage
-          type: integer
-        normalizedGenre:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_genre_normalized
+        title:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_title
           type: string
-          nullable: true
-        numOfL:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_verse_lines
-          type: integer
-        wordCountSp:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_word_tokens_in_sp
-          type: integer
-        numOfSpeakersUnknown:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_speakers_gender_unknown
-          type: integer
-        averagePathLength:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_path_length
-          type: number
-        originalSourceYear:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_original_source_publication_year
-          type: integer
-          nullable: true
-        maxDegree:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_max_degree
-          type: integer
-        numEdges:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_num_edges
-          type: integer
         subtitle:
           description: https://dracor.org/ontology/dracor-api-ontology#play_subtitle
+          type: string
+          nullable: true
+        wikidataId:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_wikidata_id
           type: string
           nullable: true
         firstAuthor:
           description: https://dracor.org/ontology/dracor-api-ontology#play_first_author_shortname
           type: string
-        originalSourcePublisher:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_original_source_publisher
+        yearNormalized:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_normalized
+          type: integer
+          nullable: true
+        yearWritten:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_written
+          type: string
+          nullable: true
+        yearPremiered:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_premiered
+          type: string
+          nullable: true
+        yearPrinted:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_printed
+          type: string
+          nullable: true
+        datePremiered:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_date_premiered
+          type: string
+        normalizedGenre:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_genre_normalized
           type: string
           nullable: true
         libretto:
           description: https://dracor.org/ontology/dracor-api-ontology#play_is_libretto
           type: boolean
-        numConnectedComponents:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_num_connected_components
-          type: integer
-        yearWritten:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_written
-          type: string
-          nullable: true
-        numOfP:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_paragraphs
-          type: integer
-        id:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_id
-          type: string
-        wordCountText:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_word_tokens_in_text_elements
-          type: integer
-        datePremiered:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_date_premiered
-          type: string
-        size:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_size
-          type: integer
-        averageDegree:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_degree
+        density:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_density
           type: number
-        yearPrinted:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_printed
-          type: string
-          nullable: true
-        numOfSegments:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_segments
-          type: integer
-        numOfActs:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_acts
-          type: integer
-        title:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_title
-          type: string
-        wikipediaLinkCount:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_wikipedia_links
-          type: integer
-          nullable: true
         digitalSource:
           nullable: true
-        numOfPersonGroups:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_person_groups
-          type: integer
-        yearNormalized:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_normalized
-          type: integer
-          nullable: true
-        numOfCoAuthors:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_co_authors
-          type: integer
-        maxDegreeIds:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_max_degree_character_id
-          type: string
         originalSourceNumberOfPages:
           description: https://dracor.org/ontology/dracor-api-ontology#play_original_source_num_of_pages
           type: integer
           nullable: true
-        density:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_density
+        originalSourcePubPlace:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_original_source_publication_place
+          type: string
+          nullable: true
+        originalSourcePublisher:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_original_source_publisher
+          type: string
+          nullable: true
+        originalSourceYear:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_original_source_publication_year
+          type: integer
+          nullable: true
+        averageClustering:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_clustering
           type: number
+        averageDegree:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_degree
+          type: number
+        averagePathLength:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_path_length
+          type: number
+        diameter:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_diameter
+          type: integer
+        maxDegree:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_max_degree
+          type: integer
+        maxDegreeIds:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_max_degree_character_id
+          type: string
+        numOfL:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_verse_lines
+          type: integer
+        numConnectedComponents:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_num_connected_components
+          type: integer
+        numEdges:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_num_edges
+          type: integer
+        numOfActs:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_acts
+          type: integer
+        numOfCoAuthors:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_co_authors
+          type: integer
+        numOfP:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_paragraphs
+          type: integer
+        numOfPersonGroups:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_person_groups
+          type: integer
+        numOfSegments:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_segments
+          type: integer
+        numOfSpeakers:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_speakers
+          type: integer
+        numOfSpeakersMale:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_speakers_gender_male
+          type: integer
+        numOfSpeakersFemale:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_speakers_gender_female
+          type: integer
+        numOfSpeakersUnknown:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_speakers_gender_unknown
+          type: integer
+        size:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_size
+          type: integer
+        wikipediaLinkCount:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_wikipedia_links
+          type: integer
+          nullable: true
+        wordCountSp:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_word_tokens_in_sp
+          type: integer
+        wordCountStage:
+          description: https://dracor.org/ontology/dracor-api-ontology#pplay_num_of_word_tokens_in_stage
+          type: integer
+        wordCountText:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_word_tokens_in_text_elements
+          type: integer
       required:
         - id
         - name
@@ -1842,12 +1842,17 @@ components:
         - wikidataId
         - firstAuthor
         - yearNormalized
+        - yearWritten
         - yearPremiered
         - yearPrinted
-        - yearWritten
         - datePremiered
-        - digitalSource
+        - normalizedGenre
         - libretto
+        - digitalSource
+        - originalSourceNumberOfPages
+        - originalSourcePublisher
+        - originalSourcePubPlace
+        - originalSourceYear
         - averageClustering
         - averageDegree
         - averagePathLength
@@ -1855,7 +1860,6 @@ components:
         - diameter
         - maxDegree
         - maxDegreeIds
-        - normalizedGenre
         - numConnectedComponents
         - numEdges
         - numOfActs
@@ -1868,10 +1872,6 @@ components:
         - numOfSpeakersFemale
         - numOfSpeakersMale
         - numOfSpeakersUnknown
-        - originalSourceNumberOfPages
-        - originalSourcePublisher
-        - originalSourcePubPlace
-        - originalSourceYear
         - size
         - wikipediaLinkCount
         - wordCountSp
@@ -1885,16 +1885,16 @@ components:
           description: https://dracor.org/ontology/dracor-api-ontology#segment_type
           type: string
           nullable: true
-        speakers:
-          type: array
-          items:
-            type: string
         number:
           description: https://dracor.org/ontology/dracor-api-ontology#segment_number
           type: integer
         title:
           description: https://dracor.org/ontology/dracor-api-ontology#segment_title
           type: string
+        speakers:
+          type: array
+          items:
+            type: string
       required:
         - type
         - number
@@ -1939,19 +1939,16 @@ components:
       # see dutil:get-play-info
       type: object
       properties:
-        wikidataId:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_wikidata_id
-          type: string
         id:
           description: https://dracor.org/ontology/dracor-api-ontology#character_id
           type: string
-        isGroup:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_is_group
-          type: boolean
         name:
           description: https://dracor.org/ontology/dracor-api-ontology#character_name
           type: string
           nullable: true
+        isGroup:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_is_group
+          type: boolean
         sex:
           description: https://dracor.org/ontology/dracor-api-ontology#character_gender
           type: string
@@ -1960,6 +1957,9 @@ components:
             - MALE
             - FEMALE
             - UNKNOWN
+        wikidataId:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_wikidata_id
+          type: string
       required:
         - id
         - name
@@ -1998,93 +1998,96 @@ components:
       # see dutil:get-play-info
       type: object
       properties:
-        wikidataId:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_wikidata_id
+        id:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_id
           type: string
-          nullable: true
-        segments:
-          type: array
-          items:
-            $ref: '#/components/schemas/SegmentItemInPlayMetadata'
+        uri:
+          type: string
+          format: url
+        name:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_name
+          type: string
         corpus:
           description: https://dracor.org/ontology/dracor-api-ontology#play_corpus_name
           type: string
-        yearPremiered:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_premiered
+        title:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_title
+          type: string
+        subtitle:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_subtitle
           type: string
           nullable: true
-        allInIndex:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_all_in_index
-          type: number
-          nullable: true
-          minimum: 0.0
-          maximum: 1.0
         titleEn:
           description: https://dracor.org/ontology/dracor-api-ontology#play_title_en
+          type: string
+        subtitleEn:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_subtitle_en
           type: string
         authors:
           description: https://dracor.org/ontology/dracor-api-ontology#contains_play_author_data
           type: array
           items:
             $ref: '#/components/schemas/AuthorInPlayMetadata'
-        name:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_name
-          type: string
-        normalizedGenre:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_genre_normalized
-          type: string
-          nullable: true
-        subtitleEn:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_subtitle_en
-          type: string
-        characters:
-          description: https://dracor.org/ontology/dracor-api-ontology#contains_play_character_data
-          type: array
-          items:
-            $ref: '#/components/schemas/CharacterInPlayMetadata'
-        source:
-          description: https://dracor.org/ontology/dracor-api-ontology#ccontains_digital_source_data
-          $ref: '#/components/schemas/SourceInPlayMetadata'
-        subtitle:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_subtitle
-          type: string
-          nullable: true
-        libretto:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_is_libretto
-          type: boolean
-        allInSegment:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_all_in_segment
+        yearNormalized:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_normalized
           type: integer
           nullable: true
         yearWritten:
           description: https://dracor.org/ontology/dracor-api-ontology#play_year_written
           type: string
           nullable: true
-        id:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_id
+        yearPremiered:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_year_premiered
           type: string
-        datePremiered:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_date_premiered
-          type: string
+          nullable: true
         yearPrinted:
           description: https://dracor.org/ontology/dracor-api-ontology#play_year_printed
           type: string
           nullable: true
+        datePremiered:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_date_premiered
+          type: string
+        normalizedGenre:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_genre_normalized
+          type: string
+          nullable: true
+        libretto:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_is_libretto
+          type: boolean
+        allInIndex:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_all_in_index
+          type: number
+          nullable: true
+          minimum: 0.0
+          maximum: 1.0
+        allInSegment:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_all_in_segment
+          type: integer
+          nullable: true
+        characters:
+          description: https://dracor.org/ontology/dracor-api-ontology#contains_play_character_data
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacterInPlayMetadata'
+        segments:
+          type: array
+          items:
+            $ref: '#/components/schemas/SegmentItemInPlayMetadata'
         relations:
           description: https://dracor.org/ontology/dracor-api-ontology#contains_character_relation_data
           type: array
           items:
             $ref: '#/components/schemas/RelationItemInPlayMetadata'
-        title:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_title
-          type: string
-        yearNormalized:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_normalized
-          type: integer
-          nullable: true
+        source:
+          description: https://dracor.org/ontology/dracor-api-ontology#ccontains_digital_source_data
+          $ref: '#/components/schemas/SourceInPlayMetadata'
         originalSource:
           description: https://dracor.org/ontology/dracor-api-ontology#play_original_source_full_citation
           type: string
+        wikidataId:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_wikidata_id
+          type: string
+          nullable: true
       required:
         - id
         - uri
@@ -2092,38 +2095,38 @@ components:
         - corpus
         - title
         - authors
+        - yearPremiered
+        - yearPrinted
+        - yearWritten
+        - yearNormalized
         - normalizedGenre
         - libretto
         - allInSegment
         - allInIndex
         - characters
         - segments
-        - yearPremiered
-        - yearPrinted
-        - yearWritten
-        - yearNormalized
     NodeInPlayMetrics:
       # see dutil:get-play-metrics
       type: object
       properties:
-        closeness:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_node_closeness
-          type: number
+        id:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_id
+          type: string
         betweenness:
           description: https://dracor.org/ontology/dracor-api-ontology#haracter_node_betweenness
+          type: number
+        closeness:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_node_closeness
           type: number
         degree:
           description: https://dracor.org/ontology/dracor-api-ontology#character_node_degree
           type: integer
-        weightedDegree:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_node_weighted_degree
-          type: integer
-        id:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_id
-          type: string
         eigenvector:
           description: https://dracor.org/ontology/dracor-api-ontology#character_node_eigenvector
           type: number
+        weightedDegree:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_node_weighted_degree
+          type: integer
       required:
         - id
         - betweenness
@@ -2135,44 +2138,37 @@ components:
       # see dutil:get-play-metrics
       type: object
       properties:
-        averagePathLength:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_path_length
-          type: number
-        diameter:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_diameter
-          type: integer
+        id:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_id
+          type: string
+        name:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_name
+          type: string
+        corpus:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_corpus_name
+          type: string
         nodes:
           type: array
           items:
             $ref: '#/components/schemas/NodeInPlayMetrics'
-        corpus:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_corpus_name
-          type: string
         averageClustering:
           description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_clustering
           type: number
-        maxDegree:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_degree
-          type: integer
-        wikipediaLinkCount:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_wikipedia_links
-          type: integer
-          nullable: true
-        id:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_id
-          type: string
-        numEdges:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_num_edges
-          type: integer
-        size:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_size
-          type: integer
         averageDegree:
           description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_degree
           type: number
-        name:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_name
-          type: string
+        averagePathLength:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_path_length
+          type: number
+        density:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_density
+          type: number
+        diameter:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_diameter
+          type: integer
+        maxDegree:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_degree
+          type: integer
         maxDegreeIds:
           description: https://dracor.org/ontology/dracor-api-ontology#play_network_max_degree_character_id
           type: array
@@ -2181,70 +2177,45 @@ components:
         numConnectedComponents:
           description: https://dracor.org/ontology/dracor-api-ontology#play_network_num_connected_components
           type: integer
-        density:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_density
-          type: number
+        numEdges:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_num_edges
+          type: integer
+        size:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_network_size
+          type: integer
+        wikipediaLinkCount:
+          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_wikipedia_links
+          type: integer
+          nullable: true
       required:
         - id
         - name
         - corpus
         - nodes
-        - wikipediaLinkCount
-        - averagePathLength
-        - diameter
         - averageClustering
-        - maxDegree
-        - numEdges
-        - size
         - averageDegree
+        - averagePathLength
+        - density
+        - diameter
+        - maxDegree
         - maxDegreeIds
         - numConnectedComponents
-        - density
+        - numEdges
+        - size
+        - wikipediaLinkCount
     Character:
       type: object
       properties:
-        closeness:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_node_closeness
-          type: number
-          nullable: true
-        wikidataId:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_wikidata_id
-          type: string
-        betweenness:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_node_betweenness
-          type: number
-          nullable: true
-        degree:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_node_degree
-          type: integer
-          nullable: true
-        weightedDegree:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_node_weighted_degree
-          type: integer
-          nullable: true
-        numOfSpeechActs:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_num_of_sp
-          type: integer
         id:
           description: https://dracor.org/ontology/dracor-api-ontology#character_id
           type: string
-        eigenvector:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_node_eigenvector
-          type: number
-          nullable: true
-        numOfScenes:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_num_of_segments
-          type: integer
-        numOfWords:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_num_of_word_tokens
-          type: integer
-        isGroup:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_is_group
-          type: boolean
         name:
           description: https://dracor.org/ontology/dracor-api-ontology#character_name
           type: string
           nullable: true
+        isGroup:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_is_group
+          type: boolean
         gender:
           description: https://dracor.org/ontology/dracor-api-ontology#character_gender
           type: string
@@ -2253,31 +2224,60 @@ components:
           - FEMALE
           - UNKNOWN
           nullable: true
+        betweenness:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_node_betweenness
+          type: number
+          nullable: true
+        closeness:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_node_closeness
+          type: number
+          nullable: true
+        degree:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_node_degree
+          type: integer
+          nullable: true
+        eigenvector:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_node_eigenvector
+          type: number
+          nullable: true
+        numOfScenes:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_num_of_segments
+          type: integer
+        numOfSpeechActs:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_num_of_sp
+          type: integer
+        numOfWords:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_num_of_word_tokens
+          type: integer
+        weightedDegree:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_node_weighted_degree
+          type: integer
+          nullable: true
+        wikidataId:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_wikidata_id
+          type: string
       required:
         - id
         - name
         - isGroup
         - gender
+        - betweenness
+        - closeness
+        - degree
+        - eigenvector
         - numOfScenes
         - numOfSpeechActs
         - numOfWords
-        - degree
         - weightedDegree
-        - closeness
-        - betweenness
-        - eigenvector
     SpokenTextByCharacter:
       # see api:get-spoken-text-by-character
       type: object
       properties:
-        roles:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_role
-          type: array
-          nullable: true
-          items:
-            type: string
         id:
           description: https://dracor.org/ontology/dracor-api-ontology#character_id
+          type: string
+        label:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_name
           type: string
         isGroup:
           description: https://dracor.org/ontology/dracor-api-ontology#character_is_group
@@ -2289,9 +2289,12 @@ components:
           - FEMALE
           - UNKNOWN
           nullable: true
-        label:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_name
-          type: string
+        roles:
+          description: https://dracor.org/ontology/dracor-api-ontology#character_role
+          type: array
+          nullable: true
+          items:
+            type: string
         text:
           description: https://dracor.org/ontology/dracor-api-ontology#character_spoken_text
           type: array
@@ -2308,19 +2311,19 @@ components:
       # see dutil:get-plays-with-character
       type: object
       properties:
-        characterName:
-          type: string
-        title:
-          type: string
         id:
           type: string
         uri:
           type: string
           format: url
+        title:
+          type: string
         authors:
           type: array
           items:
             type: string
+        characterName:
+          type: string
       required:
         - id
         - uri

--- a/api.yaml
+++ b/api.yaml
@@ -1393,16 +1393,16 @@ components:
       type: object
       properties:
         name:
-          description: https://dracor.org/ontology/dracor-api-ontology#service_name
+          # ontology: #service_name
           type: string
         version:
-          description: https://dracor.org/ontology/dracor-api-ontology#service_version
+          # ontology: #service_version
           type: string
         status:
-          description: https://dracor.org/ontology/dracor-api-ontology#service_development_stage
+          # ontology: #service_development_stage
           type: string
         existdb:
-          description: https://dracor.org/ontology/dracor-api-ontology#service_dependency_is_existdb_version
+          # ontology: #service_dependency_is_existdb_version
           type: string
         base:
           type: string
@@ -1421,13 +1421,13 @@ components:
       type: object
       properties:
         text:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_word_tokens_in_text_elements
+          # ontology: #corpus_num_of_word_tokens_in_text_elements
           type: integer
         stage:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_word_tokens_in_stage
+          # ontology: #corpus_num_of_word_tokens_in_stage
           type: integer
         sp:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_word_tokens_in_sp
+          # ontology: #corpus_num_of_word_tokens_in_sp
           type: integer
       required:
         - text
@@ -1437,31 +1437,31 @@ components:
       type: object
       properties:
         characters:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_characters
+          # ontology: #corpus_num_of_characters
           type: integer
         male:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_characters_male
+          # ontology: #corpus_num_of_characters_male
           type: integer
         female:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_characters_female
+          # ontology: #corpus_num_of_characters_female
           type: integer
         stage:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_stage
+          # ontology: #corpus_num_of_stage
           type: integer
         sp:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_sp
+          # ontology: #corpus_num_of_sp
           type: integer
         text:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_tei_text_elements
+          # ontology: #corpus_num_of_tei_text_elements
           type: integer
         plays:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_num_of_plays
+          # ontology: #corpus_num_of_plays
           type: integer
         wordcount:
-          description: https://dracor.org/ontology/dracor-api-ontology#contains_corpus_wordcount_data
+          # ontology: #contains_corpus_wordcount_data
           $ref: '#/components/schemas/WordCounts'
         updated:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_metrics_date_updated
+          # ontology: #corpus_metrics_date_updated
           type: string
       required:
         - characters
@@ -1477,32 +1477,32 @@ components:
       type: object
       properties:
         uri:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_uri
+          # ontology: #corpus_uri
           type: string
           format: url
         name:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_name
+          # ontology: #corpus_name
           type: string
         title:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_title
+          # ontology: #corpus_title
           type: string
         acronym:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_acronym
+          # ontology: #corpus_acronym
           type: string
         commit:
           type: string
         description:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_description
+          # ontology: #corpus_description
           type: string
         licence:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_licence
+          # ontology: #corpus_licence
           type: string
         licenceUrl:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_licence_url
+          # ontology: #corpus_licence_url
           type: string
           format: url
         repository:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_repository
+          # ontology: #corpus_repository
           type: string
           format: url
         metrics:
@@ -1518,11 +1518,11 @@ components:
       type: object
       properties:
         name:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_digital_source_name
+          # ontology: #play_digital_source_name
           type: string
           nullable: true
         url:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_digital_source_url
+          # ontology: #play_digital_source_url
           type: string
           format: url
           nullable: true
@@ -1534,10 +1534,10 @@ components:
       type: object
       properties:
         type:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_ref_external_id
+          # ontology: #play_author_ref_external_id
           type: string
         ref:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_ref_type
+          # ontology: #play_author_ref_type
           type: string
       required:
         - type
@@ -1547,32 +1547,32 @@ components:
       type: object
       properties:
         name:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_name
+          # ontology: #play_author_name
           type: string
         fullname:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_fullname
+          # ontology: #play_author_fullname
           type: string
         shortname:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_shortname
+          # ontology: #play_author_shortname
           type: string
         refs:
-          description: https://dracor.org/ontology/dracor-api-ontology#contains_external_ref_id_data
+          # ontology: #contains_external_ref_id_data
           type: array
           items:
             $ref: '#/components/schemas/ExternalReferenceResourceId'
         alsoKnownAs:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_also_known_as
+          # ontology: #play_author_also_known_as
           type: array
           items:
             type: string
         nameEn:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_name_en
+          # ontology: #play_author_name_en
           type: string
         fullnameEn:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_fullname_en
+          # ontology: #play_author_fullname_en
           type: string
         shortnameEn:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_shortname_en
+          # ontology: #play_author_shortname_en
           type: string
       required:
         - name
@@ -1584,62 +1584,62 @@ components:
       type: object
       properties:
         id:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_id
+          # ontology: #play_id
           type: string
         uri:
           type: string
           format: url
         name:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_name
+          # ontology: #play_name
           type: string
         title:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_title
+          # ontology: #play_title
           type: string
         subtitle:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_subtitle
+          # ontology: #play_subtitle
           type: string
         titleEn:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_title_en
+          # ontology: #play_title_en
           type: string
         subtitleEn:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_subtitle_en
+          # ontology: #play_subtitle_en
           type: string
         authors:
-          description: https://dracor.org/ontology/dracor-api-ontology#contains_play_author_data
+          # ontology: #contains_play_author_data
           type: array
           items:
             $ref: '#/components/schemas/AuthorInPlayInCorpus'
         yearNormalized:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_normalized
+          # ontology: #play_year_normalized
           type: integer
           nullable: true
         yearWritten:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_written
+          # ontology: #play_year_written
           type: string
           nullable: true
         yearPremiered:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_premiered
+          # ontology: #play_year_premiered
           type: string
           nullable: true
         yearPrinted:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_printed
+          # ontology: #play_year_printed
           type: string
           nullable: true
         datePremiered:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_date_premiered
+          # ontology: #play_date_premiered
           type: string
         source:
-          description: https://dracor.org/ontology/dracor-api-ontology#contains_digital_source_data
+          # ontology: #contains_digital_source_data
           $ref: '#/components/schemas/SourceInPlayMetadata'
         networkdataCsvUrl:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_data_csv_url
+          # ontology: #play_network_data_csv_url
           type: string
           format: url
         networkSize:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_size
+          # ontology: #play_network_size
           type: integer
         wikidataId:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_wikidata_id
+          # ontology: #play_wikidata_id
           type: string
           nullable: true
       required:
@@ -1660,32 +1660,32 @@ components:
       type: object
       properties:
         name:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_name
+          # ontology: #corpus_name
           type: string
         title:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_title
+          # ontology: #corpus_title
           type: string
         acronym:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_acronym
+          # ontology: #corpus_acronym
           type: string
         description:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_description
+          # ontology: #corpus_description
           type: string
         commit:
           type: string
         repository:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_repository
+          # ontology: #corpus_repository
           type: string
           format: url
         licence:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_licence
+          # ontology: #corpus_licence
           type: string
         licenceUrl:
-          description: https://dracor.org/ontology/dracor-api-ontology#corpus_licence_url
+          # ontology: #corpus_licence_url
           type: string
           format: url
         plays:
-          description: https://dracor.org/ontology/dracor-api-ontology#contains_play_data
+          # ontology: #contains_play_data
           type: array
           items:
             $ref: '#/components/schemas/PlayInCorpus'
@@ -1698,141 +1698,141 @@ components:
       type: object
       properties:
         id:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_id
+          # ontology: #play_id
           type: string
         name:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_name
+          # ontology: #play_name
           type: string
         title:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_title
+          # ontology: #play_title
           type: string
         subtitle:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_subtitle
+          # ontology: #play_subtitle
           type: string
           nullable: true
         wikidataId:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_wikidata_id
+          # ontology: #play_wikidata_id
           type: string
           nullable: true
         firstAuthor:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_first_author_shortname
+          # ontology: #play_first_author_shortname
           type: string
         yearNormalized:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_normalized
+          # ontology: #play_year_normalized
           type: integer
           nullable: true
         yearWritten:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_written
+          # ontology: #play_year_written
           type: string
           nullable: true
         yearPremiered:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_premiered
+          # ontology: #play_year_premiered
           type: string
           nullable: true
         yearPrinted:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_printed
+          # ontology: #play_year_printed
           type: string
           nullable: true
         datePremiered:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_date_premiered
+          # ontology: #play_date_premiered
           type: string
         normalizedGenre:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_genre_normalized
+          # ontology: #play_genre_normalized
           type: string
           nullable: true
         libretto:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_is_libretto
+          # ontology: #play_is_libretto
           type: boolean
         density:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_density
+          # ontology: #play_network_density
           type: number
         digitalSource:
           nullable: true
         originalSourceNumberOfPages:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_original_source_num_of_pages
+          # ontology: #play_original_source_num_of_pages
           type: integer
           nullable: true
         originalSourcePubPlace:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_original_source_publication_place
+          # ontology: #play_original_source_publication_place
           type: string
           nullable: true
         originalSourcePublisher:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_original_source_publisher
+          # ontology: #play_original_source_publisher
           type: string
           nullable: true
         originalSourceYear:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_original_source_publication_year
+          # ontology: #play_original_source_publication_year
           type: integer
           nullable: true
         averageClustering:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_clustering
+          # ontology: #play_network_average_clustering
           type: number
         averageDegree:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_degree
+          # ontology: #play_network_average_degree
           type: number
         averagePathLength:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_path_length
+          # ontology: #play_network_average_path_length
           type: number
         diameter:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_diameter
+          # ontology: #play_network_diameter
           type: integer
         maxDegree:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_max_degree
+          # ontology: #play_network_max_degree
           type: integer
         maxDegreeIds:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_max_degree_character_id
+          # ontology: #play_network_max_degree_character_id
           type: string
         numOfL:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_verse_lines
+          # ontology: #play_num_of_verse_lines
           type: integer
         numConnectedComponents:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_num_connected_components
+          # ontology: #play_network_num_connected_components
           type: integer
         numEdges:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_num_edges
+          # ontology: #play_network_num_edges
           type: integer
         numOfActs:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_acts
+          # ontology: #play_num_of_acts
           type: integer
         numOfCoAuthors:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_co_authors
+          # ontology: #play_num_of_co_authors
           type: integer
         numOfP:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_paragraphs
+          # ontology: #play_num_of_paragraphs
           type: integer
         numOfPersonGroups:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_person_groups
+          # ontology: #play_num_of_person_groups
           type: integer
         numOfSegments:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_segments
+          # ontology: #play_num_of_segments
           type: integer
         numOfSpeakers:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_speakers
+          # ontology: #play_num_of_speakers
           type: integer
         numOfSpeakersMale:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_speakers_gender_male
+          # ontology: #play_num_of_speakers_gender_male
           type: integer
         numOfSpeakersFemale:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_speakers_gender_female
+          # ontology: #play_num_of_speakers_gender_female
           type: integer
         numOfSpeakersUnknown:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_speakers_gender_unknown
+          # ontology: #play_num_of_speakers_gender_unknown
           type: integer
         size:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_size
+          # ontology: #play_network_size
           type: integer
         wikipediaLinkCount:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_wikipedia_links
+          # ontology: #play_num_of_wikipedia_links
           type: integer
           nullable: true
         wordCountSp:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_word_tokens_in_sp
+          # ontology: #play_num_of_word_tokens_in_sp
           type: integer
         wordCountStage:
-          description: https://dracor.org/ontology/dracor-api-ontology#pplay_num_of_word_tokens_in_stage
+          # ontology: #pplay_num_of_word_tokens_in_stage
           type: integer
         wordCountText:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_word_tokens_in_text_elements
+          # ontology: #play_num_of_word_tokens_in_text_elements
           type: integer
       required:
         - id
@@ -1882,14 +1882,14 @@ components:
       type: object
       properties:
         type:
-          description: https://dracor.org/ontology/dracor-api-ontology#segment_type
+          # ontology: #segment_type
           type: string
           nullable: true
         number:
-          description: https://dracor.org/ontology/dracor-api-ontology#segment_number
+          # ontology: #segment_number
           type: integer
         title:
-          description: https://dracor.org/ontology/dracor-api-ontology#segment_title
+          # ontology: #segment_title
           type: string
         speakers:
           type: array
@@ -1908,27 +1908,27 @@ components:
           items:
             $ref: '#/components/schemas/ExternalReferenceResourceId'
         alsoKnownAs:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_also_known_as
+          # ontology: #play_author_also_known_as
           type: array
           items:
             type: string
         fullnameEn:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_fullname_en
+          # ontology: #play_author_fullname_en
           type: string
         name:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_name
+          # ontology: #play_author_name
           type: string
         shortnameEn:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_shortname_en
+          # ontology: #play_author_shortname_en
           type: string
         nameEn:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_name_en
+          # ontology: #play_author_name_en
           type: string
         fullname:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_fullname
+          # ontology: #play_author_fullname
           type: string
         shortname:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_author_shortname
+          # ontology: #play_author_shortname
           type: string
       required:
         - name
@@ -1940,17 +1940,17 @@ components:
       type: object
       properties:
         id:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_id
+          # ontology: #character_id
           type: string
         name:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_name
+          # ontology: #character_name
           type: string
           nullable: true
         isGroup:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_is_group
+          # ontology: #character_is_group
           type: boolean
         sex:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_gender
+          # ontology: #character_gender
           type: string
           nullable: true
           enum:
@@ -1958,7 +1958,7 @@ components:
             - FEMALE
             - UNKNOWN
         wikidataId:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_wikidata_id
+          # ontology: #character_wikidata_id
           type: string
       required:
         - id
@@ -1970,10 +1970,10 @@ components:
       type: object
       properties:
         directed:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_relation_is_directed
+          # ontology: #character_relation_is_directed
           type: boolean
         type:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_relation_type
+          # ontology: #character_relation_type
           type: string
           enum:
           - parent_of
@@ -1984,10 +1984,10 @@ components:
           - spouses
           - friends
         source:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_relation_from
+          # ontology: #character_relation_from
           type: string
         target:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_relation_to
+          # ontology: #character_relation_to
           type: string
       required:
         - directed
@@ -1999,73 +1999,73 @@ components:
       type: object
       properties:
         id:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_id
+          # ontology: #play_id
           type: string
         uri:
           type: string
           format: url
         name:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_name
+          # ontology: #play_name
           type: string
         corpus:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_corpus_name
+          # ontology: #play_corpus_name
           type: string
         title:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_title
+          # ontology: #play_title
           type: string
         subtitle:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_subtitle
+          # ontology: #play_subtitle
           type: string
           nullable: true
         titleEn:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_title_en
+          # ontology: #play_title_en
           type: string
         subtitleEn:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_subtitle_en
+          # ontology: #play_subtitle_en
           type: string
         authors:
-          description: https://dracor.org/ontology/dracor-api-ontology#contains_play_author_data
+          # ontology: #contains_play_author_data
           type: array
           items:
             $ref: '#/components/schemas/AuthorInPlayMetadata'
         yearNormalized:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_normalized
+          # ontology: #play_year_normalized
           type: integer
           nullable: true
         yearWritten:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_written
+          # ontology: #play_year_written
           type: string
           nullable: true
         yearPremiered:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_premiered
+          # ontology: #play_year_premiered
           type: string
           nullable: true
         yearPrinted:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_year_printed
+          # ontology: #play_year_printed
           type: string
           nullable: true
         datePremiered:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_date_premiered
+          # ontology: #play_date_premiered
           type: string
         normalizedGenre:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_genre_normalized
+          # ontology: #play_genre_normalized
           type: string
           nullable: true
         libretto:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_is_libretto
+          # ontology: #play_is_libretto
           type: boolean
         allInIndex:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_all_in_index
+          # ontology: #play_all_in_index
           type: number
           nullable: true
           minimum: 0.0
           maximum: 1.0
         allInSegment:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_all_in_segment
+          # ontology: #play_all_in_segment
           type: integer
           nullable: true
         characters:
-          description: https://dracor.org/ontology/dracor-api-ontology#contains_play_character_data
+          # ontology: #contains_play_character_data
           type: array
           items:
             $ref: '#/components/schemas/CharacterInPlayMetadata'
@@ -2074,18 +2074,18 @@ components:
           items:
             $ref: '#/components/schemas/SegmentItemInPlayMetadata'
         relations:
-          description: https://dracor.org/ontology/dracor-api-ontology#contains_character_relation_data
+          # ontology: #contains_character_relation_data
           type: array
           items:
             $ref: '#/components/schemas/RelationItemInPlayMetadata'
         source:
-          description: https://dracor.org/ontology/dracor-api-ontology#ccontains_digital_source_data
+          # ontology: #ccontains_digital_source_data
           $ref: '#/components/schemas/SourceInPlayMetadata'
         originalSource:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_original_source_full_citation
+          # ontology: #play_original_source_full_citation
           type: string
         wikidataId:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_wikidata_id
+          # ontology: #play_wikidata_id
           type: string
           nullable: true
       required:
@@ -2110,22 +2110,22 @@ components:
       type: object
       properties:
         id:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_id
+          # ontology: #character_id
           type: string
         betweenness:
-          description: https://dracor.org/ontology/dracor-api-ontology#haracter_node_betweenness
+          # ontology: #haracter_node_betweenness
           type: number
         closeness:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_node_closeness
+          # ontology: #character_node_closeness
           type: number
         degree:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_node_degree
+          # ontology: #character_node_degree
           type: integer
         eigenvector:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_node_eigenvector
+          # ontology: #character_node_eigenvector
           type: number
         weightedDegree:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_node_weighted_degree
+          # ontology: #character_node_weighted_degree
           type: integer
       required:
         - id
@@ -2139,52 +2139,52 @@ components:
       type: object
       properties:
         id:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_id
+          # ontology: #play_id
           type: string
         name:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_name
+          # ontology: #play_name
           type: string
         corpus:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_corpus_name
+          # ontology: #play_corpus_name
           type: string
         nodes:
           type: array
           items:
             $ref: '#/components/schemas/NodeInPlayMetrics'
         averageClustering:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_clustering
+          # ontology: #play_network_average_clustering
           type: number
         averageDegree:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_degree
+          # ontology: #play_network_average_degree
           type: number
         averagePathLength:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_path_length
+          # ontology: #play_network_average_path_length
           type: number
         density:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_density
+          # ontology: #play_network_density
           type: number
         diameter:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_diameter
+          # ontology: #play_network_diameter
           type: integer
         maxDegree:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_average_degree
+          # ontology: #play_network_average_degree
           type: integer
         maxDegreeIds:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_max_degree_character_id
+          # ontology: #play_network_max_degree_character_id
           type: array
           items:
             type: string
         numConnectedComponents:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_num_connected_components
+          # ontology: #play_network_num_connected_components
           type: integer
         numEdges:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_num_edges
+          # ontology: #play_network_num_edges
           type: integer
         size:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_network_size
+          # ontology: #play_network_size
           type: integer
         wikipediaLinkCount:
-          description: https://dracor.org/ontology/dracor-api-ontology#play_num_of_wikipedia_links
+          # ontology: #play_num_of_wikipedia_links
           type: integer
           nullable: true
       required:
@@ -2207,17 +2207,17 @@ components:
       type: object
       properties:
         id:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_id
+          # ontology: #character_id
           type: string
         name:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_name
+          # ontology: #character_name
           type: string
           nullable: true
         isGroup:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_is_group
+          # ontology: #character_is_group
           type: boolean
         gender:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_gender
+          # ontology: #character_gender
           type: string
           enum:
           - MALE
@@ -2225,36 +2225,36 @@ components:
           - UNKNOWN
           nullable: true
         betweenness:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_node_betweenness
+          # ontology: #character_node_betweenness
           type: number
           nullable: true
         closeness:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_node_closeness
+          # ontology: #character_node_closeness
           type: number
           nullable: true
         degree:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_node_degree
+          # ontology: #character_node_degree
           type: integer
           nullable: true
         eigenvector:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_node_eigenvector
+          # ontology: #character_node_eigenvector
           type: number
           nullable: true
         numOfScenes:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_num_of_segments
+          # ontology: #character_num_of_segments
           type: integer
         numOfSpeechActs:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_num_of_sp
+          # ontology: #character_num_of_sp
           type: integer
         numOfWords:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_num_of_word_tokens
+          # ontology: #character_num_of_word_tokens
           type: integer
         weightedDegree:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_node_weighted_degree
+          # ontology: #character_node_weighted_degree
           type: integer
           nullable: true
         wikidataId:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_wikidata_id
+          # ontology: #character_wikidata_id
           type: string
       required:
         - id
@@ -2274,13 +2274,13 @@ components:
       type: object
       properties:
         id:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_id
+          # ontology: #character_id
           type: string
         label:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_name
+          # ontology: #character_name
           type: string
         isGroup:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_is_group
+          # ontology: #character_is_group
           type: boolean
         gender:
           type: string
@@ -2290,13 +2290,13 @@ components:
           - UNKNOWN
           nullable: true
         roles:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_role
+          # ontology: #character_role
           type: array
           nullable: true
           items:
             type: string
         text:
-          description: https://dracor.org/ontology/dracor-api-ontology#character_spoken_text
+          # ontology: #character_spoken_text
           type: array
           items:
             type: string


### PR DESCRIPTION
This PR declares the required properties in the schemas of the OpenAPI documentation. We need this for the pydracor rewrite.

I used the opportunity to also reorder the properties the structure and similarities in the schemas easier to comprehend.

I also converted the descriptions with ontology links, originally added by @ingoboerner, into comments. Let's restore them once we have an ontology with actual targets to link to.