### PR TITLE
Fix navigation ressource properties of DTS endpoint

### DIFF
--- a/modules/dts.xqm
+++ b/modules/dts.xqm
@@ -2785,10 +2785,10 @@ declare function local:navigation-basic-response($tei as element(tei:TEI), $requ
     let $navigation := if ($navigation-url != "") then $navigation-url else $ddts:navigation-base || "?resource=" || $doc-uri || "{&amp;ref,start,end,down}" (: maybe add also page, althoug not plan to implement it now:)
     :)
     (: 'passage' has been renamed to 'document' in "unstable" see https://github.com/mromanello/DTS-validator/blob/6f1f0fb6c78a815411c6c5cce57840599dc2c475/NOTES.md#validation-reports-explained :)
-    let $document := $ddts:documents-base || "{?resource,ref,start,end,mediaType}"
+    let $document := $ddts:documents-base || "?resource=" || $doc-uri || "{&amp;ref,start,end,mediaType}"
     (: according to the spec this endpoint only includes passage and navigation in the Navigation object :)
     (: let $collection := $ddts:collections-base || "{?id,nav}" :)
-    let $navigation := $ddts:navigation-base || "{?resource,ref,start,end,down}"
+    let $navigation := $ddts:navigation-base || "?resource=" || $doc-uri || "{&amp;ref,start,end,down}"
     
     let $citationTrees := local:generate-citationTrees($tei)
 

--- a/modules/dts.xqm
+++ b/modules/dts.xqm
@@ -2800,9 +2800,11 @@ declare function local:navigation-basic-response($tei as element(tei:TEI), $requ
     let $resource := map {
         "@id" : $doc-uri,
         "@type" : "Resource",
+        "document" : $document,
+        "collection" : $collection,
+        "navigation" : $navigation,
         "citationTrees" : $citationTrees,
-        "mediaTypes" : array {"application/tei+xml", "text/plain"},
-        "collection" : $collection
+        "mediaTypes" : array {"application/tei+xml", "text/plain"}
     }
 
      return
@@ -2812,10 +2814,6 @@ declare function local:navigation-basic-response($tei as element(tei:TEI), $requ
          "@id" : $request-id,
          "@type" : "Navigation",
          "dtsVersion" : $ddts:spec-version,
-         (: "passage" has been renamed to "document" in version "unstable" :)
-         "document" : $document,
-         (: "collection" : $collection, :) (: this according to the spec:)
-         "navigation" : $navigation,
          "resource" : $resource
      }
  };


### PR DESCRIPTION
Places the properties `navigation`, `collection` and `document` inside the `resource` object in the response of the DTSm navigation endpoint, see issue #283 