### PR TITLE
Implement plain text endpoint

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -430,6 +430,24 @@ paths:
           description: >-
             There is no corpus with the given `corpusname`.
 
+  /corpora/{corpusname}/plays/{playname}/txt:
+    get:
+      summary: Get plain text of a single play
+      operationId: play-txt
+      tags: [public]
+      parameters:
+        - $ref: "#/components/parameters/corpusname"
+        - $ref: "#/components/parameters/playname"
+      responses:
+        '200':
+          description: Returns play as plain text.
+          content:
+            text/plain:
+              schema:
+                type: string
+        '404':
+          description: Unknown play (or corpus)
+
   /corpora/{corpusname}/plays/{playname}/characters:
     get:
       summary: Get a list of characters of a play

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -813,6 +813,29 @@ function api:play-tei($corpusname, $playname) {
 };
 
 (:~
+ : Get plain text representation of a single play
+ :
+ : @param $corpusname Corpus name
+ : @param $playname Play name
+ : @result plain text
+ :)
+declare
+  %rest:GET
+  %rest:path("/v1/corpora/{$corpusname}/plays/{$playname}/txt")
+  %rest:produces("text/plain")
+  %output:media-type("text/plain")
+function api:play-txt($corpusname, $playname) {
+  let $doc := dutil:get-doc($corpusname, $playname)
+  return
+    if (not($doc)) then
+      <rest:response>
+        <http:response status="404"/>
+      </rest:response>
+    else
+      dutil:extract-text($doc)
+};
+
+(:~
  : Add new or update existing TEI document
  :
  : When sending a PUT request to a new play URI, the request body is stored in

--- a/modules/util.xqm
+++ b/modules/util.xqm
@@ -117,14 +117,14 @@ declare function dutil:distinct-speakers ($parent as element()*) as item()* {
 };
 
 (:~
- : Extract plain text from TEI document or element.
+ : Extract plain text from document or element.
  :
- : @param $tei TEI element
+ : @param $node element
  : @return Plain text content
  :)
-declare function dutil:extract-text($tei as node()) as xs:string* {
+declare function dutil:extract-text($node as node()) as xs:string {
   let $xsl := doc("/db/apps/dracor-v1/tei-to-txt.xsl")
-  let $text := transform:transform($tei, $xsl, ())
+  let $text := transform:transform($node, $xsl, ())
   (: trim leading spaces :)
   return replace($text, '\n +', '&#10;') => replace('^\s+', '')
 };

--- a/modules/util.xqm
+++ b/modules/util.xqm
@@ -11,6 +11,7 @@ import module namespace config = "http://dracor.org/ns/exist/v1/config"
 
 declare namespace tei = "http://www.tei-c.org/ns/1.0";
 declare namespace json = "http://www.w3.org/2013/XSL/json";
+declare namespace transform = "http://exist-db.org/xquery/transform";
 
 (:~
  : Provide map of files and paths related to a play.
@@ -113,6 +114,19 @@ declare function dutil:distinct-speakers ($parent as element()*) as item()* {
     (: (see https://github.com/dracor-org/gerdracor/issues/6) :)
     where string-length($ref) > 1
     return substring($ref, 2)
+};
+
+(:~
+ : Extract plain text from TEI document or element.
+ :
+ : @param $tei TEI element
+ : @return Plain text content
+ :)
+declare function dutil:extract-text($tei as node()) as xs:string* {
+  let $xsl := doc("/db/apps/dracor-v1/tei-to-txt.xsl")
+  let $text := transform:transform($tei, $xsl, ())
+  (: trim leading spaces :)
+  return replace($text, '\n +', '&#10;') => replace('^\s+', '')
 };
 
 (:~

--- a/tei-to-txt.xsl
+++ b/tei-to-txt.xsl
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<xsl:stylesheet version="3.0"
+  xmlns="http://www.w3.org/1999/xhtml"
+  xmlns:tei="http://www.tei-c.org/ns/1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:output method="text" encoding="UTF-8" />
+
+  <xsl:template match="tei:TEI">
+    <xsl:apply-templates />
+  </xsl:template>
+
+  <xsl:template match="tei:teiHeader"></xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
This implements an endpoint `/corpora/{corpusname}/plays/{playname}/txt` that provides the full content of a single play as plain text. At the moment it uses a simple XSL transformation to strip off all xml tags and to completely omit the teiHeader contents. Leading white space at the beginning of lines is removed.

There is room for improvement, for instance, markup like `<choice>` should be handled, and `<note>` elements should be either omitted or moved to the end of the text. 

see #281