### PR TITLE
Open the 'relation' parameter

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -869,14 +869,15 @@ paths:
           schema:
             type: string
             enum: [FEMALE, MALE, UNKNOWN]
-        - $ref: "#/components/parameters/relationName"
-        - $ref: "#/components/parameters/relationRole"
         - name: role
           description: Speaker role
           in: query
           required: false
           schema:
             type: string
+        - $ref: "#/components/parameters/relationMutual"
+        - $ref: "#/components/parameters/relationActive"
+        - $ref: "#/components/parameters/relationPassive"
       responses:
         '200':
           description: Returns plain text document
@@ -885,7 +886,7 @@ paths:
               schema:
                 type: string
         '400':
-          description: Invalid value for `gender` or `relation-role` parameters
+          description: Invalid value for `gender` parameter
         '404':
           description: Unknown play (or corpus)
 
@@ -1401,11 +1402,16 @@ components:
         munoz_refugio:
           value: munoz-refugio
           summary: "P. Muñoz Seca: El Refugio (SpanDraCor)"
-    relationName:
+    relationMutual:
       name: relation
       description: |
-        Speaker relation name. The possible values can vary depending on the
-        corpus. For examples see the the section
+        Name of an undirected relation between speakers. When a valid relation
+        is given, the response lists only results associated with speakers that
+        are participants in that relation (i.e. are referenced in the
+        `@mutual` attribute of the relation element).
+
+        The possible values can vary depending on the corpus. For examples see
+        the section
         [Relations of Characters](/doc/odd#section-character-relations) of the
         Encoding Guidelines.
       in: query
@@ -1419,25 +1425,52 @@ components:
           value: friends
         spouses:
           value: spouses
+    relationActive:
+      name: relation-active
+      description: |
+        Name of a directed relation between speakers. When a valid relation is
+        given, the response lists only results associated with speakers that
+        are active participants in that relation (i.e. are referenced in the
+        `@active` attribute of the relation element).
+
+        The possible values can vary depending on the corpus. For examples see
+        the section
+        [Relations of Characters](/doc/odd#section-character-relations) of the
+        Encoding Guidelines.
+      in: query
+      required: false
+      schema:
+        type: string
+      examples:
         parent_of:
           value: parent_of
         related_with:
           value: related_with
         associated_with:
           value: associated_with
-    relationRole:
-      name: relation-role
+    relationPassive:
+      name: relation-passive
       description: |
-        For directed relations this selects either the passive or the active
-        participants. This parameter needs to be combined with the
-        `relation` parameter, otherwise it is ignored.
+        Name of a directed relation between speakers. When a valid relation is
+        given, the response lists only results associated with speakers that
+        are passive participants in that relation (i.e. are referenced in the
+        `@passive` attribute of the relation element).
+
+        The possible values can vary depending on the corpus. For examples see
+        the section
+        [Relations of Characters](/doc/odd#section-character-relations) of the
+        Encoding Guidelines.
       in: query
       required: false
       schema:
         type: string
-        enum:
-          - passive
-          - active
+      examples:
+        parent_of:
+          value: parent_of
+        related_with:
+          value: related_with
+        associated_with:
+          value: associated_with
   schemas:
     Info:
       type: object

--- a/api.yaml
+++ b/api.yaml
@@ -851,35 +851,28 @@ paths:
   /corpora/{corpusname}/plays/{playname}/spoken-text:
     get:
       summary: Get spoken text of a play (excluding stage directions)
+      description: |
+        The lines or paragraphs of text to include can be filtered by the
+        gender, role or relation of the speakers.
+
+        Note that the response may be empty when you use filter parameters and
+        there is no speaker matching the filter
       operationId: play-spoken-text
       tags: [public]
       parameters:
         - $ref: "#/components/parameters/corpusname"
         - $ref: "#/components/parameters/playname"
         - name: gender
+          description: Speaker gender
           in: query
           required: false
           schema:
             type: string
             enum: [FEMALE, MALE, UNKNOWN]
-        - name: relation
-          in: query
-          required: false
-          schema:
-            type: string
-            enum:
-              - siblings
-              - friends
-              - spouses
-              - parent_of_active
-              - parent_of_passive
-              - lover_of_active
-              - lover_of_passive
-              - related_with_active
-              - related_with_passive
-              - associated_with_active
-              - associated_with_passive
+        - $ref: "#/components/parameters/relationName"
+        - $ref: "#/components/parameters/relationRole"
         - name: role
+          description: Speaker role
           in: query
           required: false
           schema:
@@ -891,6 +884,8 @@ paths:
             text/plain:
               schema:
                 type: string
+        '400':
+          description: Invalid value for `gender` or `relation-role` parameters
         '404':
           description: Unknown play (or corpus)
 
@@ -1406,6 +1401,43 @@ components:
         munoz_refugio:
           value: munoz-refugio
           summary: "P. Muñoz Seca: El Refugio (SpanDraCor)"
+    relationName:
+      name: relation
+      description: |
+        Speaker relation name. The possible values can vary depending on the
+        corpus. For examples see the the section
+        [Relations of Characters](/doc/odd#section-character-relations) of the
+        Encoding Guidelines.
+      in: query
+      required: false
+      schema:
+        type: string
+      examples:
+        siblings:
+          value: siblings
+        friends:
+          value: friends
+        spouses:
+          value: spouses
+        parent_of:
+          value: parent_of
+        related_with:
+          value: related_with
+        associated_with:
+          value: associated_with
+    relationRole:
+      name: relation-role
+      description: |
+        For directed relations this selects either the passive or the active
+        participants. This parameter needs to be combined with the
+        `relation` parameter, otherwise it is ignored.
+      in: query
+      required: false
+      schema:
+        type: string
+        enum:
+          - passive
+          - active
   schemas:
     Info:
       type: object

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -1447,11 +1447,13 @@ declare
   %rest:query-param("gender", "{$gender}")
   %rest:query-param("role", "{$role}")
   %rest:query-param("relation", "{$relation}")
-  %rest:query-param("relation-role", "{$relation-role}")
+  %rest:query-param("relation-active", "{$relation-active}")
+  %rest:query-param("relation-passive", "{$relation-passive}")
   %rest:produces("text/plain")
   %output:media-type("text/plain")
 function api:spoken-text(
-  $corpusname, $playname, $gender, $role, $relation, $relation-role
+  $corpusname, $playname, $gender, $role, $relation, $relation-active,
+  $relation-passive
 ) {
   let $doc := dutil:get-doc($corpusname, $playname)
   let $genders := tokenize($gender, ',')
@@ -1470,20 +1472,13 @@ function api:spoken-text(
         </rest:response>,
         "gender must be ""FEMALE"", ""MALE"", or ""UNKNOWN"""
       )
-    else if (
-      $relation-role and
-      not($relation-role != ("active", "passive"))
-    ) then
-      (
-        <rest:response>
-          <http:response status="400"/>
-        </rest:response>,
-        "relation-role must be ""active"" or ""passive"""
-      )
     else
-      let $sp := if ($gender or $relation or $role) then
+      let $sp := if (
+        $gender or $relation or $relation-active or $relation-passive or $role
+        ) then
         dutil:get-speech-filtered(
-          $doc//tei:body, $gender, $role, $relation, $relation-role
+          $doc//tei:body, $gender, $role, $relation, $relation-active,
+          $relation-passive
         )
       else
         dutil:get-speech($doc//tei:body, ())

--- a/modules/util.xqm
+++ b/modules/util.xqm
@@ -117,6 +117,83 @@ declare function dutil:distinct-speakers ($parent as element()*) as item()* {
 };
 
 (:~
+ : Retrieve list of speaker IDs of a play filtered by gender, role or relation
+ :
+ : This function retrieve a list of IDs from the particDesc of a play that
+ : can be filtered by gender, role and/or relation.
+ :
+ : The $relation parameter should be a value used in the `name` attribute of
+ : the tei:listRelation/tei:relation element. For directed relations the active
+ : or passive side can be selected using the $relation-role parameter.
+ :
+ : To support the behavior in API versions prior to 1.1.0 the relation role can
+ : also be specified by suffixing the relation name with '_active' or
+ : '_passive'. The $relation-role parameter, when used together with a suffix,
+ : will have precedence.
+ :
+ : @param $tei Document element
+ : @param $gender Gender of speaker
+ : @param $role Role of speaker.
+ : @param $relation Relation of speaker.
+ : @param $relation-role Relation role (active|passive).
+ :)
+declare function dutil:get-filtered-speakers (
+  $tei as element(tei:TEI),
+  $gender as xs:string*,
+  $role as xs:string*,
+  $relation as xs:string*,
+  $relation-role as xs:string*
+) as xs:string* {
+  let $genders := tokenize($gender, ',')
+  let $roles := tokenize($role, ',')
+
+  (: extract possible relation role from $relation :)
+  let $ana := analyze-string($relation, "_(active|passive)$")
+  let $rel := $ana//fn:non-match/text()
+  let $suffix := $ana//fn:group[@nr="1"]/text()
+
+  let $relside := if ($relation-role) then $relation-role
+    else if ($suffix) then $suffix else ()
+
+  let $listPerson := $tei//tei:particDesc/tei:listPerson
+  let $relations := $listPerson/tei:listRelation
+  let $ids := $listPerson/(tei:person|tei:personGrp)
+    [
+      (not($gender) or @sex = $genders) and
+      (not($role) or tokenize(@role, '\s+') = $roles)
+    ]/@xml:id/string()
+
+  let $filtered := for $id in $ids
+    return if (not($rel)) then
+      $id
+    else if (
+      not($relside)
+      and $relations/tei:relation
+        [@name = $rel and (
+          contains(@mutual||' ', '#'||$id||' ') or
+          contains(@active||' ', '#'||$id||' ') or
+          contains(@passive||' ', '#'||$id||' ')
+        )]
+    ) then
+      $id
+    else if (
+      $relside = 'active'
+      and $relations/tei:relation
+        [@name = $rel and contains(@active||' ', '#'||$id||' ')]
+    ) then
+      $id
+    else if (
+      $relside = 'passive'
+      and $relations/tei:relation
+        [@name = $rel and contains(@passive||' ', '#'||$id||' ')]
+    ) then
+      $id
+    else ()
+
+  return $filtered
+};
+
+(:~
  : Extract plain text from document or element.
  :
  : @param $node element
@@ -173,76 +250,33 @@ declare function dutil:get-speech-by-gender (
 };
 
 (:~
- : Retrieve and filter spoken text by gender and/or relation
+ : Retrieve and filter spoken text by gender, role and/or relation
  :
  : This function selects the `tei:p` and `tei:l` elements inside those `tei:sp`
  : descendants of a given element $parent that reference a speaker with the
- : given gender and/or relation. It then strips these elements possible stage
- : directions (`tei:stage`).
+ : given gender, role and/or relation. It then strips these elements of possible
+ : stage directions and notes (`tei:stage`, `tei:note`).
  :
- : Possible values for the relation parameter are:
- :  - siblings
- :  - friends
- :  - spouses
- :  - parent_of_active
- :  - lover_of_active
- :  - related_with_active
- :  - associated_with_active
- :  - parent_of_passive
- :  - lover_of_passive
- :  - related_with_passive
- :  - associated_with_passive
+ : For the relation parameter also see dutil:get-filtered-speakers().
  :
  : @param $parent Element to search in
  : @param $gender Gender of speaker
- : @param $relation Relation of speaker.
+ : @param $role Role of speaker
+ : @param $relation Relation of speaker
+ : @param $relation-role Relation role (active|passive)
  :)
 declare function dutil:get-speech-filtered (
   $parent as element(),
   $gender as xs:string*,
+  $role as xs:string*,
   $relation as xs:string*,
-  $role as xs:string*
+  $relation-role as xs:string*
 ) as item()* {
-  let $undirected := ("siblings", "friends", "spouses")
-  let $directed := ("parent_of", "lover_of", "related_with", "associated_with")
-  let $active := for $x in $directed return $x || '_active'
-  let $passive := for $x in $directed return $x || '_passive'
-  let $rel := replace($relation, '_(active|passive)$', '')
-  let $genders := tokenize($gender, ',')
-  let $roles := tokenize($role, ',')
+  let $speakers := dutil:get-filtered-speakers(
+    $parent/ancestor::tei:TEI, $gender, $role, $relation, $relation-role
+  )
 
-  let $listPerson := $parent/ancestor::tei:TEI//tei:particDesc/tei:listPerson
-  let $relations := $listPerson/tei:listRelation
-  let $ids := $listPerson/(tei:person|tei:personGrp)
-    [
-      (not($gender) or @sex = $genders) and
-      (not($role) or tokenize(@role, '\s+') = $roles)
-    ]/@xml:id/string()
-
-  let $filtered := for $id in $ids
-    return if (not($relation)) then
-      $id
-    else if (
-      $relation = $undirected
-      and $relations/tei:relation
-        [@name = $relation and contains(@mutual||' ', '#'||$id||' ')]
-    ) then
-      $id
-    else if (
-      $relation = $active
-      and $relations/tei:relation
-        [@name = $rel and contains(@active||' ', '#'||$id||' ')]
-    ) then
-      $id
-    else if (
-      $relation = $passive
-      and $relations/tei:relation
-        [@name = $rel and contains(@passive||' ', '#'||$id||' ')]
-    ) then
-      $id
-    else ()
-
-  let $refs := for $id in $filtered return '#'||$id
+  let $refs := for $id in $speakers return '#'||$id
   let $sp := $parent//tei:sp[@who = $refs]//(tei:p|tei:l)
   return functx:remove-elements-deep($sp, ('*:stage', '*:note'))
 };

--- a/modules/util.xqm
+++ b/modules/util.xqm
@@ -212,8 +212,7 @@ declare function dutil:get-speech-filtered (
   let $roles := tokenize($role, ',')
 
   let $listPerson := $parent/ancestor::tei:TEI//tei:particDesc/tei:listPerson
-  let $relations := $listPerson/tei:listRelation[@type="personal"]
-
+  let $relations := $listPerson/tei:listRelation
   let $ids := $listPerson/(tei:person|tei:personGrp)
     [
       (not($gender) or @sex = $genders) and
@@ -1214,7 +1213,7 @@ declare function dutil:get-relations (
   $playname as xs:string
 ) as map()* {
   let $doc := dutil:get-doc($corpusname, $playname)
-  let $listRel := $doc//tei:listRelation[@type = "personal"]
+  let $listRel := $doc//tei:particDesc/tei:listPerson/tei:listRelation
   let $relations := (
     for $rel in $listRel/tei:relation[@mutual]
       let $ids := local:tokenize($rel/@mutual)


### PR DESCRIPTION
The `/corpora/{corpusname}/plays/{playname}/spoken-text` until now defined a fixed list of possible values for the `relation` parameter that allows to limit spoken to that of character of a certain role. This PR removes this fixed list from the API and its implementation and thus allows it to work with any current or future relation name. To be able to distinguish between the active or passive participants of a relationship ~~a new `relation-role` parameter with the possible values "active" or "passive" has~~ two additional parameters `relation-active` and `relation-passive` have been introduced. The `relation` parameter is retained for undirected relations. The old way of suffixing the relation name with  "_passive" or "_active" when using the `relation` parameter is still supported.

I extended the documentation with examples for the `relation` parameter using the previously fixed values. I also added a note that responses can be empty if the query parameters don't match any speaker. 

resolve #275 
