### PR TITLE
Support both 'sex' and 'gender' attributes

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -1975,6 +1975,9 @@ components:
             - FEMALE
             - UNKNOWN
           x-dracor-feature: character_sex
+        gender:
+          type: string
+          x-dracor-feature: character_gender
         role:
           type: string
           x-dracor-feature: character_role
@@ -2248,6 +2251,9 @@ components:
           - UNKNOWN
           nullable: true
           x-dracor-feature: character_sex
+        gender:
+          type: string
+          x-dracor-feature: character_gender
         role:
           type: string
           x-dracor-feature: character_role
@@ -2318,6 +2324,9 @@ components:
           - UNKNOWN
           nullable: true
           x-dracor-feature: character_sex
+        gender:
+          type: string
+          x-dracor-feature: character_gender
         roles:
           type: array
           nullable: true

--- a/api.yaml
+++ b/api.yaml
@@ -469,7 +469,7 @@ paths:
                 [
                   {
                     "numOfSpeechActs": 171,
-                    "gender": "MALE",
+                    "sex": "MALE",
                     "numOfScenes": 21,
                     "name": "Городничий",
                     "numOfWords": 4985,
@@ -478,7 +478,7 @@ paths:
                   },
                   {
                     "numOfSpeechActs": 49,
-                    "gender": "MALE",
+                    "sex": "MALE",
                     "numOfScenes": 8,
                     "name": "Аммос Федорович",
                     "numOfWords": 748,
@@ -487,7 +487,7 @@ paths:
                   },
                   {
                     "numOfSpeechActs": 50,
-                    "gender": "MALE",
+                    "sex": "MALE",
                     "numOfScenes": 9,
                     "name": "Артемий Филиппович Земляника",
                     "numOfWords": 735,
@@ -496,7 +496,7 @@ paths:
                   },
                   {
                     "numOfSpeechActs": 24,
-                    "gender": "MALE",
+                    "sex": "MALE",
                     "numOfScenes": 8,
                     "name": "Лука Лукич",
                     "numOfWords": 291,
@@ -508,7 +508,7 @@ paths:
               schema:
                 type: string
               example: |
-                id,name,gender,isGroup,numOfScenes,numOfSpeechActs,numOfWords
+                id,name,sex,isGroup,numOfScenes,numOfSpeechActs,numOfWords
                 "gorodnichij","Городничий","MALE","false","21","171","4985"
                 "ammos_fedorovich_ljapkin_tjapkin","Аммос Федорович","MALE","false","8","49","748"
                 "artemij_filippovich_zemljanika","Артемий Филиппович Земляника","MALE","false","9","50","735"
@@ -532,7 +532,7 @@ paths:
               schema:
                 type: string
               example: |
-                id,name,gender,isGroup,numOfScenes,numOfSpeechActs,numOfWords
+                id,name,sex,isGroup,numOfScenes,numOfSpeechActs,numOfWords
                 "gorodnichij","Городничий","MALE","false","21","171","4985"
                 "ammos_fedorovich_ljapkin_tjapkin","Аммос Федорович","MALE","false","8","49","748"
                 "artemij_filippovich_zemljanika","Артемий Филиппович Земляника","MALE","false","9","50","735"
@@ -656,7 +656,7 @@ paths:
                   </meta>
                   <graph mode="static">
                     <attributes class="node" mode="static">
-                      <attribute id="gender" title="Gender" type="string"/>
+                      <attribute id="sex" title="Sex" type="string"/>
                       <attribute id="person-group" title="Person group" type="boolean"/>
                       <attribute id="number-of-words" title="Number of spoken words" type="integer"/>
                     </attributes>
@@ -668,63 +668,63 @@ paths:
                         <attvalues>
                           <attvalue for="person-group" value="0"/>
                           <attvalue for="number-of-words" value="1037"/>
-                          <attvalue for="gender" value="FEMALE"/>
+                          <attvalue for="sex" value="FEMALE"/>
                         </attvalues>
                       </node>
                       <node id="menalkas" label="Menalkas">
                         <attvalues>
                           <attvalue for="person-group" value="0"/>
                           <attvalue for="number-of-words" value="1509"/>
-                          <attvalue for="gender" value="MALE"/>
+                          <attvalue for="sex" value="MALE"/>
                         </attvalues>
                       </node>
                       <node id="nisus" label="Nisus">
                         <attvalues>
                           <attvalue for="person-group" value="0"/>
                           <attvalue for="number-of-words" value="2203"/>
-                          <attvalue for="gender" value="MALE"/>
+                          <attvalue for="sex" value="MALE"/>
                         </attvalues>
                       </node>
                       <node id="atalanta" label="Atalanta">
                         <attvalues>
                           <attvalue for="person-group" value="0"/>
                           <attvalue for="number-of-words" value="2307"/>
-                          <attvalue for="gender" value="FEMALE"/>
+                          <attvalue for="sex" value="FEMALE"/>
                         </attvalues>
                       </node>
                       <node id="corydon" label="Corydon">
                         <attvalues>
                           <attvalue for="person-group" value="0"/>
                           <attvalue for="number-of-words" value="1373"/>
-                          <attvalue for="gender" value="MALE"/>
+                          <attvalue for="sex" value="MALE"/>
                         </attvalues>
                       </node>
                       <node id="damon" label="Damon">
                         <attvalues>
                           <attvalue for="person-group" value="0"/>
                           <attvalue for="number-of-words" value="2674"/>
-                          <attvalue for="gender" value="MALE"/>
+                          <attvalue for="sex" value="MALE"/>
                         </attvalues>
                       </node>
                       <node id="amaryllis" label="Amaryllis">
                         <attvalues>
                           <attvalue for="person-group" value="0"/>
                           <attvalue for="number-of-words" value="823"/>
-                          <attvalue for="gender" value="FEMALE"/>
+                          <attvalue for="sex" value="FEMALE"/>
                         </attvalues>
                       </node>
                       <node id="myrtillus" label="Myrtillus">
                         <attvalues>
                           <attvalue for="person-group" value="0"/>
                           <attvalue for="number-of-words" value="1720"/>
-                          <attvalue for="gender" value="MALE"/>
+                          <attvalue for="sex" value="MALE"/>
                         </attvalues>
                       </node>
                       <node id="damoetas" label="Damötas">
                         <attvalues>
                           <attvalue for="person-group" value="0"/>
                           <attvalue for="number-of-words" value="679"/>
-                          <attvalue for="gender" value="MALE"/>
+                          <attvalue for="sex" value="MALE"/>
                         </attvalues>
                       </node>
                     </nodes>
@@ -765,52 +765,52 @@ paths:
                 <graphml xmlns="http://graphml.graphdrawing.org/xmlns">
                   <key attr.name="label" attr.type="string" for="node" id="label"/>
                   <key attr.name="Relation" attr.type="string" for="edge" id="relation"/>
-                  <key attr.name="Gender" attr.type="string" for="node" id="gender"/>
+                  <key attr.name="Sex" attr.type="string" for="node" id="sex"/>
                   <key attr.name="Person group" attr.type="boolean" for="node" id="person-group"/>
                   <graph edgedefault="undirected">
                     <node id="doris">
                       <data key="label">Doris</data>
-                      <data key="gender">FEMALE</data>
+                      <data key="sex">FEMALE</data>
                       <data key="person-group">false</data>
                     </node>
                     <node id="menalkas">
                       <data key="label">Menalkas</data>
-                      <data key="gender">MALE</data>
+                      <data key="sex">MALE</data>
                       <data key="person-group">false</data>
                     </node>
                     <node id="nisus">
                       <data key="label">Nisus</data>
-                      <data key="gender">MALE</data>
+                      <data key="sex">MALE</data>
                       <data key="person-group">false</data>
                     </node>
                     <node id="atalanta">
                       <data key="label">Atalanta</data>
-                      <data key="gender">FEMALE</data>
+                      <data key="sex">FEMALE</data>
                       <data key="person-group">false</data>
                     </node>
                     <node id="corydon">
                       <data key="label">Corydon</data>
-                      <data key="gender">MALE</data>
+                      <data key="sex">MALE</data>
                       <data key="person-group">false</data>
                     </node>
                     <node id="damon">
                       <data key="label">Damon</data>
-                      <data key="gender">MALE</data>
+                      <data key="sex">MALE</data>
                       <data key="person-group">false</data>
                     </node>
                     <node id="amaryllis">
                       <data key="label">Amaryllis</data>
-                      <data key="gender">FEMALE</data>
+                      <data key="sex">FEMALE</data>
                       <data key="person-group">false</data>
                     </node>
                     <node id="myrtillus">
                       <data key="label">Myrtillus</data>
-                      <data key="gender">MALE</data>
+                      <data key="sex">MALE</data>
                       <data key="person-group">false</data>
                     </node>
                     <node id="damoetas">
                       <data key="label">Damötas</data>
-                      <data key="gender">MALE</data>
+                      <data key="sex">MALE</data>
                       <data key="person-group">false</data>
                     </node>
                     <edge id="1" directed="false" source="amaryllis" target="atalanta">
@@ -856,7 +856,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/corpusname"
         - $ref: "#/components/parameters/playname"
-        - name: gender
+        - name: sex
           in: query
           required: false
           schema:
@@ -1829,13 +1829,13 @@ components:
           x-dracor-feature: play_num_of_speakers
         numOfSpeakersMale:
           type: integer
-          x-dracor-feature: play_num_of_speakers_gender_male
+          x-dracor-feature: play_num_of_speakers_sex_male
         numOfSpeakersFemale:
           type: integer
-          x-dracor-feature: play_num_of_speakers_gender_female
+          x-dracor-feature: play_num_of_speakers_sex_female
         numOfSpeakersUnknown:
           type: integer
-          x-dracor-feature: play_num_of_speakers_gender_unknown
+          x-dracor-feature: play_num_of_speakers_sex_unknown
         size:
           type: integer
           x-dracor-feature: play_network_size
@@ -1974,7 +1974,7 @@ components:
             - MALE
             - FEMALE
             - UNKNOWN
-          x-dracor-feature: character_gender
+          x-dracor-feature: character_sex
         role:
           type: string
           x-dracor-feature: character_role
@@ -2240,14 +2240,14 @@ components:
         isGroup:
           type: boolean
           x-dracor-feature: character_is_group
-        gender:
+        sex:
           type: string
           enum:
           - MALE
           - FEMALE
           - UNKNOWN
           nullable: true
-          x-dracor-feature: character_gender
+          x-dracor-feature: character_sex
         role:
           type: string
           x-dracor-feature: character_role
@@ -2287,7 +2287,7 @@ components:
         - id
         - name
         - isGroup
-        - gender
+        - sex
         - betweenness
         - closeness
         - degree
@@ -2310,14 +2310,14 @@ components:
           # ontology: #character_is_group
           type: boolean
           x-dracor-feature: character_is_group
-        gender:
+        sex:
           type: string
           enum:
           - MALE
           - FEMALE
           - UNKNOWN
           nullable: true
-          x-dracor-feature: character_gender
+          x-dracor-feature: character_sex
         roles:
           type: array
           nullable: true
@@ -2333,7 +2333,7 @@ components:
         - id
         - label
         - isGroup
-        - gender
+        - sex
         - roles
         - text
     PlayWithWikidataCharacter:

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -994,7 +994,7 @@ declare function local:make-gexf-nodes($speakers, $doc) as element()* {
         <attvalue for="number-of-words" value="{$wc}" />
       {
         if ($sex) then
-          <attvalue for="gender" value="{$sex}"></attvalue>
+          <attvalue for="sex" value="{$sex}"></attvalue>
         else ()
       }
       </attvalues>
@@ -1066,7 +1066,7 @@ function api:networkdata-gexf($corpusname, $playname) {
           </meta>
           <graph mode="static" defaultedgetype="undirected">
             <attributes class="node" mode="static">
-              <attribute id="gender" title="Gender" type="string"/>
+              <attribute id="sex" title="Sex" type="string"/>
               <attribute id="person-group" title="Person group" type="boolean"/>
               <attribute id="number-of-words" title="Number of spoken words" type="integer"/>
             </attributes>
@@ -1135,7 +1135,7 @@ function api:networkdata-graphml($corpusname, $playname) {
           <key attr.name="label" attr.type="string" for="node" id="label"/>
           <key attr.name="Edge Label" attr.type="string" for="edge" id="edgelabel"/>
           <key attr.name="weight" attr.type="double" for="edge" id="weight"/>
-          <key attr.name="Gender" attr.type="string" for="node" id="gender"/>
+          <key attr.name="Sex" attr.type="string" for="node" id="sex"/>
           <key attr.name="Person group" attr.type="boolean" for="node" id="person-group"/>
           <key attr.name="Number of spoken words" attr.type="int" for="node" id="number-of-words"/>
           <graph edgedefault="undirected">
@@ -1148,7 +1148,7 @@ function api:networkdata-graphml($corpusname, $playname) {
               return
                 <node id="{$id}" xmlns="http://graphml.graphdrawing.org/xmlns">
                   <data key="label">{$label}</data>
-                  {if ($sex) then <data key="gender">{$sex}</data> else ()}
+                  {if ($sex) then <data key="sex">{$sex}</data> else ()}
                   <data key="person-group">
                     {if ($n?isGroup) then "true" else "false"}
                   </data>
@@ -1270,7 +1270,7 @@ function api:relations-gexf($corpusname, $playname) {
           </meta>
           <graph mode="static">
             <attributes class="node" mode="static">
-              <attribute id="gender" title="Gender" type="string"/>
+              <attribute id="sex" title="Sex" type="string"/>
               <attribute id="person-group" title="Person group" type="boolean"/>
               <attribute id="number-of-words" title="Number of spoken words" type="integer"/>
             </attributes>
@@ -1340,7 +1340,7 @@ function api:relations-graphml($corpusname, $playname) {
         <graphml xmlns="http://graphml.graphdrawing.org/xmlns">
           <key attr.name="label" attr.type="string" for="node" id="label"/>
           <key attr.name="Relation" attr.type="string" for="edge" id="relation"/>
-          <key attr.name="Gender" attr.type="string" for="node" id="gender"/>
+          <key attr.name="Sex" attr.type="string" for="node" id="sex"/>
           <key attr.name="Person group" attr.type="boolean" for="node" id="person-group"/>
           <graph edgedefault="undirected">
             {
@@ -1351,7 +1351,7 @@ function api:relations-graphml($corpusname, $playname) {
               return
                 <node id="{$id}" xmlns="http://graphml.graphdrawing.org/xmlns">
                   <data key="label">{$label}</data>
-                  {if ($sex) then <data key="gender">{$sex}</data> else ()}
+                  {if ($sex) then <data key="sex">{$sex}</data> else ()}
                   <data key="person-group">
                     {if ($n?isGroup) then "true" else "false"}
                   </data>
@@ -1403,7 +1403,7 @@ declare
 function api:characters-info-csv($corpusname, $playname) {
   let $info := dutil:characters-info($corpusname, $playname)
   let $keys := (
-    "id", "name", "gender", "isGroup",
+    "id", "name", "sex", "isGroup",
     "numOfScenes", "numOfSpeechActs", "numOfWords", "wikidataId",
     "degree", "weightedDegree", "betweenness", "closeness", "eigenvector"
   )
@@ -1435,7 +1435,7 @@ function api:characters-info-csv-ext($corpusname, $playname) {
  :
  : @param $corpusname Corpus name
  : @param $playname Play name
- : @param $gender Gender ("MALE"|"FEMALE"|"UNKNOWN")
+ : @param $sex Sex ("MALE"|"FEMALE"|"UNKNOWN")
  : @param $relation Relation ("siblings"|"friends"|spouses"|"parent_of_active"|
  :   "parent_of_passive"|"lover_of_active"|"lover_of_passive"|
  :   "related_with_active"|"related_with_passive"|"associated_with_active"|
@@ -1446,32 +1446,32 @@ function api:characters-info-csv-ext($corpusname, $playname) {
 declare
   %rest:GET
   %rest:path("/v1/corpora/{$corpusname}/plays/{$playname}/spoken-text")
-  %rest:query-param("gender", "{$gender}")
+  %rest:query-param("sex", "{$sex}")
   %rest:query-param("relation", "{$relation}")
   %rest:query-param("role", "{$role}")
   %rest:produces("text/plain")
   %output:media-type("text/plain")
-function api:spoken-text($corpusname, $playname, $gender, $relation, $role) {
+function api:spoken-text($corpusname, $playname, $sex, $relation, $role) {
   let $doc := dutil:get-doc($corpusname, $playname)
-  let $genders := tokenize($gender, ',')
+  let $sexes := tokenize($sex, ',')
   return
     if (not($doc)) then
       <rest:response>
         <http:response status="404"/>
       </rest:response>
     else if (
-      $gender and
-      $genders[.!="MALE" and .!="FEMALE" and .!="UNKNOWN"]
+      $sex and
+      $sexes[.!="MALE" and .!="FEMALE" and .!="UNKNOWN"]
     ) then
       (
         <rest:response>
           <http:response status="400"/>
         </rest:response>,
-        "gender must be ""FEMALE"", ""MALE"", or ""UNKNOWN"""
+        "sex must be ""FEMALE"", ""MALE"", or ""UNKNOWN"""
       )
     else
-      let $sp := if ($gender or $relation or $role) then
-        dutil:get-speech-filtered($doc//tei:body, $gender, $relation, $role)
+      let $sp := if ($sex or $relation or $role) then
+        dutil:get-speech-filtered($doc//tei:body, $sex, $relation, $role)
       else
         dutil:get-speech($doc//tei:body, ())
       let $txt := string-join(($sp/normalize-space(), ""), '&#10;')
@@ -1487,7 +1487,7 @@ declare function local:get-text-by-character ($doc) {
       tei:personGrp[@xml:id=$id]/tei:name[1] |
       tei:persName[@xml:id=$id]
     )
-    let $gender := $label/parent::*/@sex/string()
+    let $sex := $label/parent::*/@sex/string()
     let $role := $label/parent::*/@role/string()
     let $isGroup := if ($label/parent::tei:personGrp)
     then true() else false()
@@ -1496,7 +1496,7 @@ declare function local:get-text-by-character ($doc) {
       "id": $id,
       "label": $label/text(),
       "isGroup": $isGroup,
-      "gender": $gender,
+      "sex": $sex,
       "roles": array {tokenize($role, '\s+')},
       "text": array {for $l in $sp return $l/normalize-space()}
     }
@@ -1573,12 +1573,12 @@ function api:spoken-text-by-character-csv($corpusname, $playname) {
     else
       let $texts := local:get-text-by-character($doc)
       return (
-        "ID,Label,Type,Gender,Text&#10;",
+        "ID,Label,Type,Sex,Text&#10;",
         for $t in $texts?*
         let $type := if ($t?isGroup) then "personGrp" else "person"
         let $text := string-join($t?text?*, '&#10;')
         return $t?id || ',"' || dutil:csv-escape($t?label) || '","' ||
-          $type  || '","' || $t?gender || '","' ||
+          $type  || '","' || $t?sex || '","' ||
           dutil:csv-escape($text) || '"&#10;'
       )
 };

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -1488,18 +1488,22 @@ declare function local:get-text-by-character ($doc) {
       tei:persName[@xml:id=$id]
     )
     let $sex := $label/parent::*/@sex/string()
+    let $gender := $label/parent::*/@gender/string()
     let $role := $label/parent::*/@role/string()
     let $isGroup := if ($label/parent::tei:personGrp)
     then true() else false()
     let $sp := dutil:get-speech($doc//tei:body, $id)
-    return map {
-      "id": $id,
-      "label": $label/text(),
-      "isGroup": $isGroup,
-      "sex": $sex,
-      "roles": array {tokenize($role, '\s+')},
-      "text": array {for $l in $sp return $l/normalize-space()}
-    }
+    return map:merge((
+      map {
+        "id": $id,
+        "label": $label/text(),
+        "isGroup": $isGroup,
+        "sex": $sex,
+        "roles": array {tokenize($role, '\s+')},
+        "text": array {for $l in $sp return $l/normalize-space()}
+      },
+      if ($gender) then map:entry("gender", $gender) else ()
+    ))
   }
 };
 

--- a/modules/util.xqm
+++ b/modules/util.xqm
@@ -1034,6 +1034,7 @@ declare function dutil:get-play-info(
           )
           let $name := $node/(tei:persName | tei:name)[1]/text()
           let $sex := $node/@sex/string()
+          let $gender := $node/@gender/string()
           let $role := $node/@role/string()
           let $isGroup := if ($node/name() eq 'personGrp')
             then true() else false()
@@ -1045,6 +1046,7 @@ declare function dutil:get-play-info(
               "isGroup": $isGroup,
               "sex": if($sex) then $sex else ()
             },
+            if ($gender) then map:entry("gender", $gender) else (),
             if ($role) then map:entry("role", $role) else (),
             if ($wikidata-id) then map:entry("wikidataId", $wikidata-id) else ()
           ))
@@ -1167,6 +1169,7 @@ declare function dutil:characters-info (
       )
       let $name := $node/(tei:persName | tei:name)[1]/text()
       let $sex := $node/@sex/string()
+      let $gender := $node/@gender/string()
       let $role := $node/@role/string()
       let $isGroup := if ($node/name() eq 'personGrp')
         then true() else false()
@@ -1191,6 +1194,7 @@ declare function dutil:characters-info (
           "betweenness": $metrics-node/betweenness/number(.),
           "eigenvector": $eigenvector
         },
+        if ($gender) then map:entry("gender", $gender) else (),
         if ($role) then map:entry("role", $role) else (),
         if ($wikidata-id) then map:entry("wikidataId", $wikidata-id) else ()
       ))

--- a/modules/util.xqm
+++ b/modules/util.xqm
@@ -150,22 +150,22 @@ declare function dutil:get-speech (
 };
 
 (:~
- : Retrieve and filter spoken text by gender
+ : Retrieve and filter spoken text by sex
  :
  : This function selects the `tei:p` and `tei:l` elements inside those `tei:sp`
  : descendants of a given element $parent that reference a speaker with the
- : given gender. It then strips these elements possible stage directions
+ : given sex. It then strips these elements possible stage directions
  : (`tei:stage`).
  :
  : @param $parent Element to search in
- : @param $gender Gender of speaker
+ : @param $sex Sex of speaker
  :)
-declare function dutil:get-speech-by-gender (
+declare function dutil:get-speech-by-sex (
   $parent as element(),
-  $gender as xs:string+
+  $sex as xs:string+
 ) as item()* {
   let $ids := $parent/ancestor::tei:TEI//tei:particDesc
-              /tei:listPerson/(tei:person|tei:personGrp)[@sex = $gender]
+              /tei:listPerson/(tei:person|tei:personGrp)[@sex = $sex]
               /@xml:id/string()
   let $refs := for $id in $ids return '#'||$id
   let $sp := $parent//tei:sp[@who = $refs]//(tei:p|tei:l)
@@ -173,11 +173,11 @@ declare function dutil:get-speech-by-gender (
 };
 
 (:~
- : Retrieve and filter spoken text by gender and/or relation
+ : Retrieve and filter spoken text by sex and/or relation
  :
  : This function selects the `tei:p` and `tei:l` elements inside those `tei:sp`
  : descendants of a given element $parent that reference a speaker with the
- : given gender and/or relation. It then strips these elements possible stage
+ : given sex and/or relation. It then strips these elements possible stage
  : directions (`tei:stage`).
  :
  : Possible values for the relation parameter are:
@@ -194,12 +194,12 @@ declare function dutil:get-speech-by-gender (
  :  - associated_with_passive
  :
  : @param $parent Element to search in
- : @param $gender Gender of speaker
+ : @param $sex Sex of speaker
  : @param $relation Relation of speaker.
  :)
 declare function dutil:get-speech-filtered (
   $parent as element(),
-  $gender as xs:string*,
+  $sex as xs:string*,
   $relation as xs:string*,
   $role as xs:string*
 ) as item()* {
@@ -208,7 +208,7 @@ declare function dutil:get-speech-filtered (
   let $active := for $x in $directed return $x || '_active'
   let $passive := for $x in $directed return $x || '_passive'
   let $rel := replace($relation, '_(active|passive)$', '')
-  let $genders := tokenize($gender, ',')
+  let $sexes := tokenize($sex, ',')
   let $roles := tokenize($role, ',')
 
   let $listPerson := $parent/ancestor::tei:TEI//tei:particDesc/tei:listPerson
@@ -216,7 +216,7 @@ declare function dutil:get-speech-filtered (
 
   let $ids := $listPerson/(tei:person|tei:personGrp)
     [
-      (not($gender) or @sex = $genders) and
+      (not($sex) or @sex = $sexes) and
       (not($role) or tokenize(@role, '\s+') = $roles)
     ]/@xml:id/string()
 
@@ -1180,7 +1180,7 @@ declare function dutil:characters-info (
           "id": $id,
           "name": $name,
           "isGroup": $isGroup,
-          "gender": if($sex) then $sex else (),
+          "sex": if($sex) then $sex else (),
           "numOfScenes": count($segments?*[?speakers = $id]),
           "numOfSpeechActs": count($tei//tei:sp[@who = '#'||$id]),
           "numOfWords": dutil:num-of-spoken-words($tei, $id),


### PR DESCRIPTION
With the introduction of the `@gender` attribute in dracor-org/dracor-schema#94 we should support this attribute along with `@sex` in the API output. For this reason this PR renames the previous `gender` property to `sex` and adds a new optional `gender` attribute to the `play-info`, `get-characters` and `play-spoken-text-by-character` endpoints. These properties now carry the values of the respective TEI attributes.  