### PR TITLE
Adjust types for WordCounts schema

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -1504,13 +1504,16 @@ components:
       type: object
       properties:
         text:
-          type: integer
+          type: number
+          format: double
           x-dracor-feature: corpus_num_of_word_tokens_in_text_elements
         stage:
-          type: integer
+          type: number
+          format: double
           x-dracor-feature: corpus_num_of_word_tokens_in_stage
         sp:
-          type: integer
+          type: number
+          format: double
           x-dracor-feature: corpus_num_of_word_tokens_in_sp
       required:
         - text


### PR DESCRIPTION
For high numbers the API issues the values for the individual word counts in scientific or E notation (see
https://en.wikipedia.org/wiki/Scientific_notation#E_notation). To make this work with pydracor-base we adjust the type to 'number'.

resolve #338