### PR TITLE
Support the use of <ref target="..."> for digital source

### DIFF
--- a/modules/util.xqm
+++ b/modules/util.xqm
@@ -635,8 +635,7 @@ declare function dutil:get-corpus-meta-data(
     )
   )
 
-  let $digitalSource := $tei//tei:sourceDesc/
-    tei:bibl[@type="digitalSource"]/tei:idno[@type="URL"][1]/text()
+  let $digitalSource := dutil:get-source($tei)?url
 
   let $origSource := $tei//tei:sourceDesc//
     tei:bibl[@type="originalSource"][1]
@@ -925,12 +924,18 @@ declare function dutil:get-titles(
  : @param $tei
  :)
 declare function dutil:get-source($tei as element(tei:TEI)) as map()? {
-  let $source := $tei//tei:sourceDesc/tei:bibl[@type="digitalSource"]
+  let $source := $tei//tei:sourceDesc/tei:bibl[@type="digitalSource"][1]
   return if (count($source)) then map:merge((
-    if ($source/tei:name) then
+    if ($source/tei:ref[@target]) then
+      map {'name': $source/tei:ref[@target][1]/normalize-space()}
+    (: deprecated :)
+    else if ($source/tei:name) then
       map {'name': $source/tei:name[1]/normalize-space()}
     else (),
-    if ($source/tei:idno[@type="URL"]) then
+    if ($source/tei:ref[@target]) then
+      map {'url': $source/tei:ref[@target][1]/@target/string()}
+    (: deprecated :)
+    else if ($source/tei:idno[@type="URL"]) then
       map {'url': $source/tei:idno[@type="URL"][1]/normalize-space()}
     else ()
   )) else ()

--- a/speakers.xq
+++ b/speakers.xq
@@ -14,6 +14,8 @@ xquery version "3.1";
 
 import module namespace config = "http://dracor.org/ns/exist/v1/config"
   at "modules/config.xqm";
+import module namespace dutil = "http://dracor.org/ns/exist/v1/util"
+  at "modules/util.xqm";
 
 declare namespace tei = "http://www.tei-c.org/ns/1.0";
 declare namespace ep = "http://earlyprint.org/ns/1.0";
@@ -33,10 +35,11 @@ return if (not($id)) then (
 ) else
   let $tei := collection($col)//tei:TEI[@xml:id = $id]
   let $id := $tei/@xml:id/string()
+  let $source := dutil:get-source($tei)
   let $epid := replace(
     tokenize(
-      $tei//tei:sourceDesc/tei:bibl[@type='digitalSource']
-        /tei:idno[@type='URL' and starts-with(., 'https://texts.earlyprint.org/works/')],
+      if (starts-with($source?url, 'https://texts.earlyprint.org/works/')) then
+        $source?url else '',
       '/'
     )[last()],
     '.xml',


### PR DESCRIPTION
In https://github.com/dracor-org/dracor-schema/pull/135 we change the recommendation of how to encode the digital source to use a `<ref>` element with a `target` attribute instead of `<name>` and `<idno>` (see also https://github.com/dracor-org/dracor-schema/issues/107#issuecomment-3316401538). This PR implements support for the new encoding while still keeping support for the old one.




