### PR TITLE
Support <editor> elements in <titleStmt>

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -1630,7 +1630,7 @@ components:
         - type
         - ref
     Author:
-      # see dutil:get-authors
+      # see dutil:get-authors, dutil:get-editors
       type: object
       properties:
         name:
@@ -1661,6 +1661,8 @@ components:
         shortnameEn:
           type: string
           x-dracor-feature: play_author_shortname_en
+        role:
+          type: string
       required:
         - name
         - fullname
@@ -1694,6 +1696,10 @@ components:
         authors:
           type: array
           x-dracor-feature: contains_play_author_data
+          items:
+            $ref: '#/components/schemas/Author'
+        editors:
+          type: array
           items:
             $ref: '#/components/schemas/Author'
         yearNormalized:
@@ -2085,6 +2091,10 @@ components:
         authors:
           type: array
           x-dracor-feature: contains_play_author_data
+          items:
+            $ref: '#/components/schemas/Author'
+        editors:
+          type: array
           items:
             $ref: '#/components/schemas/Author'
         yearNormalized:

--- a/api.yaml
+++ b/api.yaml
@@ -1629,7 +1629,7 @@ components:
       required:
         - type
         - ref
-    AuthorInPlayInCorpus:
+    Author:
       # see dutil:get-authors
       type: object
       properties:
@@ -1654,7 +1654,7 @@ components:
             type: string
         nameEn:
           type: string
-          x-dracor-feture: play_author_name_en
+          x-dracor-feature: play_author_name_en
         fullnameEn:
           type: string
           x-dracor-feature: play_author_fullname_en
@@ -1695,7 +1695,7 @@ components:
           type: array
           x-dracor-feature: contains_play_author_data
           items:
-            $ref: '#/components/schemas/AuthorInPlayInCorpus'
+            $ref: '#/components/schemas/Author'
         yearNormalized:
           type: integer
           nullable: true
@@ -1986,43 +1986,6 @@ components:
       required:
         - type
         - number
-    AuthorInPlayMetadata:
-      # FIXME: this schema seems to be identical to AuthorInPlayInCorpus, can we
-      # eliminate it?
-      type: object
-      properties:
-        refs:
-          type: array
-          items:
-            $ref: '#/components/schemas/ExternalReferenceResourceId'
-        alsoKnownAs:
-          type: array
-          x-dracor-feature: play_author_also_known_as
-          items:
-            type: string
-        fullnameEn:
-          type: string
-          x-dracor-feature: play_author_fullname_en
-        name:
-          type: string
-          x-dracor-feature: play_author_name
-        shortnameEn:
-          type: string
-          x-dracor-feature: play_author_shortname_en
-        nameEn:
-          type: string
-          x-dracor-feature: play_author_name_en
-        fullname:
-          type: string
-          x-dracor-feature: play_author_fullname
-        shortname:
-          type: string
-          x-dracor-feature: play_author_shortname
-      required:
-        - name
-        - fullname
-        - shortname
-        - refs
     CharacterInPlayMetadata:
       # see dutil:get-play-info
       type: object
@@ -2123,7 +2086,7 @@ components:
           type: array
           x-dracor-feature: contains_play_author_data
           items:
-            $ref: '#/components/schemas/AuthorInPlayMetadata'
+            $ref: '#/components/schemas/Author'
         yearNormalized:
           type: integer
           nullable: true

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -401,6 +401,7 @@ function api:corpus-index($corpusname) {
         let $titlesEng := dutil:get-titles($tei, 'en')
         let $years := dutil:get-years-iso($tei)
         let $authors := dutil:get-authors($tei)
+        let $editors := dutil:get-editors($tei)
         let $play-uri := $paths?uri
         let $metrics-url := $paths?files?metrics
         let $network-size := doc($metrics-url)//network/size/text()
@@ -418,6 +419,9 @@ function api:corpus-index($corpusname) {
           if ($titlesEng?main) then map:entry("titleEn", $titlesEng?main) else (),
           if ($titlesEng?sub) then map:entry("subtitleEn", $titlesEng?sub) else (),
           map:entry("authors", array { $authors }),
+          if (count($editors) > 0)
+            then map:entry("editors", array { $editors })
+            else (),
           if (count($source)) then map:entry("source", $source) else (),
           map:entry("yearNormalized", $yearNormalized),
           map:entry("yearPrinted", $years?print),

--- a/modules/util.xqm
+++ b/modules/util.xqm
@@ -713,32 +713,32 @@ declare function dutil:get-corpus-meta-data(
 (:~
  : Extract full name from author element.
  :
- : @param $author author element
+ : @param $person author or editor element
  : @return string
  :)
-declare function dutil:get-full-name ($author as element(tei:author)) {
-  if ($author/tei:persName) then
-    normalize-space($author/tei:persName[1])
-  else if ($author/tei:name) then
-    normalize-space($author/tei:name[1])
-  else normalize-space($author)
+declare function dutil:get-full-name ($person as element()) {
+  if ($person/tei:persName) then
+    normalize-space($person/tei:persName[1])
+  else if ($person/tei:name) then
+    normalize-space($person/tei:name[1])
+  else normalize-space($person)
 };
 
 (:~
  : Extract full name from author element by language.
  :
- : @param $author author element
+ : @param $person author or editor element
  : @param $lang language code
  : @return string
  :)
 declare function dutil:get-full-name (
-  $author as element(tei:author),
+  $person as element(),
   $lang as xs:string
 ) {
-  if ($author/tei:persName[@xml:lang=$lang]) then
-    normalize-space($author/tei:persName[@xml:lang=$lang][1])
-  else if ($author/tei:name[@xml:lang=$lang]) then
-    normalize-space($author/tei:name[@xml:lang=$lang][1])
+  if ($person/tei:persName[@xml:lang=$lang]) then
+    normalize-space($person/tei:persName[@xml:lang=$lang][1])
+  else if ($person/tei:name[@xml:lang=$lang]) then
+    normalize-space($person/tei:name[@xml:lang=$lang][1])
   else ()
 };
 
@@ -753,36 +753,36 @@ declare function local:build-short-name ($name as element()) {
 (:~
  : Extract short name from author element.
  :
- : @param $author author element
+ : @param $person author or editor element
  : @return string
  :)
-declare function dutil:get-short-name ($author as element(tei:author)) {
-  let $name := if ($author/tei:persName) then
-    $author/tei:persName[1]
-  else if ($author/tei:name) then
-    $author/tei:name[1]
+declare function dutil:get-short-name ($person as element()) {
+  let $name := if ($person/tei:persName) then
+    $person/tei:persName[1]
+  else if ($person/tei:name) then
+    $person/tei:name[1]
   else ()
 
   return if (not($name)) then
-    normalize-space($author)
+    normalize-space($person)
   else local:build-short-name($name)
 };
 
 (:~
  : Extract short name from author element by language.
  :
- : @param $author author element
+ : @param $person author or editor element
  : @param $lang language code
  : @return string
  :)
 declare function dutil:get-short-name (
-  $author as element(tei:author),
+  $person as element(),
   $lang as xs:string
 ) {
-  let $name := if ($author/tei:persName[@xml:lang=$lang]) then
-    $author/tei:persName[@xml:lang=$lang][1]
-  else if ($author/tei:name[@xml:lang=$lang]) then
-    $author/tei:name[@xml:lang=$lang][1]
+  let $name := if ($person/tei:persName[@xml:lang=$lang]) then
+    $person/tei:persName[@xml:lang=$lang][1]
+  else if ($person/tei:name[@xml:lang=$lang]) then
+    $person/tei:name[@xml:lang=$lang][1]
   else ()
 
   return if (not($name)) then () else local:build-short-name($name)
@@ -811,39 +811,75 @@ declare function local:build-sort-name ($name as element()) {
 (:~
  : Extract name from author element that is suitable for sorting.
  :
- : @param $author author element
+ : @param $person author or editor element
  : @return string
  :)
-declare function dutil:get-sort-name ($author as element(tei:author) ) {
-  let $name := if ($author/tei:persName) then
-    $author/tei:persName[1]
-  else if ($author/tei:name) then
-    $author/tei:name[1]
+declare function dutil:get-sort-name ($person as element() ) {
+  let $name := if ($person/tei:persName) then
+    $person/tei:persName[1]
+  else if ($person/tei:name) then
+    $person/tei:name[1]
   else ()
 
   return if (not($name)) then
-    normalize-space($author)
+    normalize-space($person)
   else local:build-sort-name($name)
 };
 
 (:~
  : Extract name by language from author element that is suitable for sorting.
  :
- : @param $author author element
+ : @param $person author or editor element
  : @param $lang language code
  : @return string
  :)
 declare function dutil:get-sort-name (
-  $author as element(tei:author),
+  $person as element(),
   $lang as xs:string
 ) {
-  let $name := if ($author/tei:persName[@xml:lang=$lang]) then
-    $author/tei:persName[@xml:lang=$lang][1]
-  else if ($author/tei:name[@xml:lang=$lang]) then
-    $author/tei:name[@xml:lang=$lang][1]
+  let $name := if ($person/tei:persName[@xml:lang=$lang]) then
+    $person/tei:persName[@xml:lang=$lang][1]
+  else if ($person/tei:name[@xml:lang=$lang]) then
+    $person/tei:name[@xml:lang=$lang][1]
   else ()
 
   return if (not($name)) then () else local:build-sort-name($name)
+};
+
+declare function local:get-person-record($person as element()) as map() {
+  let $name := dutil:get-sort-name($person)
+  let $fullname := dutil:get-full-name($person)
+  let $shortname := dutil:get-short-name($person)
+  let $nameEn := dutil:get-sort-name($person, 'en')
+  let $fullnameEn := dutil:get-full-name($person, 'en')
+  let $shortnameEn := dutil:get-short-name($person, 'en')
+  let $refs := array {
+    for $idno in $person/tei:idno[@type]
+    let $ref := $idno => normalize-space()
+    let $type := string($idno/@type)
+    return map {
+      "ref": $ref,
+      "type": $type
+    }
+  }
+  let $aka := array {
+    for $name in $person/tei:persName[position() > 1]
+    return $name => normalize-space()
+  }
+
+  return map:merge((
+    map {
+      "name": $name,
+      "fullname": $fullname,
+      "shortname": $shortname,
+      "refs": $refs
+    },
+    if ($person/@role) then map {"role": $person/@role/string()} else (),
+    if ($nameEn) then map {"nameEn": $nameEn} else (),
+    if ($fullnameEn) then map {"fullnameEn": $fullnameEn} else (),
+    if ($shortnameEn) then map {"shortnameEn": $shortnameEn} else (),
+    if (array:size($aka) > 0) then map {"alsoKnownAs": $aka} else ()
+  ))
 };
 
 (:~
@@ -855,38 +891,12 @@ declare function dutil:get-authors($tei as node()) as map()* {
   for $author in $tei//tei:fileDesc/tei:titleStmt/tei:author[
     not(@role="illustrator")
   ]
-  let $name := dutil:get-sort-name($author)
-  let $fullname := dutil:get-full-name($author)
-  let $shortname := dutil:get-short-name($author)
-  let $nameEn := dutil:get-sort-name($author, 'en')
-  let $fullnameEn := dutil:get-full-name($author, 'en')
-  let $shortnameEn := dutil:get-short-name($author, 'en')
-  let $refs := array {
-    for $idno in $author/tei:idno[@type]
-    let $ref := $idno => normalize-space()
-    let $type := string($idno/@type)
-    return map {
-      "ref": $ref,
-      "type": $type
-    }
-  }
-  let $aka := array {
-    for $name in $author/tei:persName[position() > 1]
-    return $name => normalize-space()
-  }
+  return local:get-person-record($author)
+};
 
-  return map:merge((
-    map {
-      "name": $name,
-      "fullname": $fullname,
-      "shortname": $shortname,
-      "refs": $refs
-    },
-    if ($nameEn) then map {"nameEn": $nameEn} else (),
-    if ($fullnameEn) then map {"fullnameEn": $fullnameEn} else (),
-    if ($shortnameEn) then map {"shortnameEn": $shortnameEn} else (),
-    if (array:size($aka) > 0) then map {"alsoKnownAs": $aka} else ()
-  ))
+declare function dutil:get-editors($tei as element(tei:TEI)) as map()* {
+  for $editor in $tei//tei:fileDesc/tei:titleStmt/tei:editor
+  return local:get-person-record($editor)
 };
 
 (:~
@@ -1074,6 +1084,7 @@ declare function dutil:get-play-info(
     }
 
     let $authors := dutil:get-authors($tei)
+    let $editors := dutil:get-editors($tei)
 
     let $text-classes := dutil:get-text-classes($tei)
 
@@ -1094,7 +1105,12 @@ declare function dutil:get-play-info(
         "name": $playname,
         "corpus": $corpusname,
         "title": $titles?main,
-        "authors": array { for $author in $authors return $author },
+        "authors": array { for $author in $authors return $author }
+      },
+      if (count($editors) > 0)
+        then map:entry("editors", array { for $editor in $editors return $editor })
+        else (),
+      map {
         "normalizedGenre": dutil:get-genre($text-classes),
         "libretto": $text-classes = 'Libretto',
         "allInSegment": $all-in-segment,


### PR DESCRIPTION
This adds an `editors` array to play metadata when the `titleStmt` of the TEI document contains one or more `editor` elements.