### PR TITLE
Add /characters endpoint listing all Wikidata-linked characters

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -992,6 +992,77 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/WikidataCharacterWithPlays'
+              example: |
+                [
+                  {
+                    "id": "Q170779",
+                    "count": 5,
+                    "plays": [
+                      {
+                        "id": "rom000029",
+                        "uri": "https://dracor.org/id/rom000029",
+                        "authors": ["Seneca"],
+                        "title": "Agamemnon",
+                        "characterId": "cassandra",
+                        "characterName": "Cassandra"
+                      },
+                      {
+                        "id": "gersh000035",
+                        "uri": "https://dracor.org/id/gersh000035",
+                        "authors": ["William Shakespeare"],
+                        "title": "Troilus und Cressida",
+                        "characterId": "kassandra",
+                        "characterName": "Kassandra"
+                      },
+                      {
+                        "id": "greek000019",
+                        "uri": "https://dracor.org/id/greek000019",
+                        "authors": ["Εὐριπίδης"],
+                        "title": "Τρῳάδες",
+                        "characterId": "kasandra",
+                        "characterName": "Κασάνδρα"
+                      },
+                      {
+                        "id": "greek000026",
+                        "uri": "https://dracor.org/id/greek000026",
+                        "authors": ["Αἰσχύλος"],
+                        "title": "Ἀγαμέμνων",
+                        "characterId": "kasandra",
+                        "characterName": "Κασάνδρα"
+                      },
+                      {
+                        "id": "shake000025",
+                        "uri": "https://dracor.org/id/shake000025",
+                        "authors": ["William Shakespeare"],
+                        "title": "Troilus and Cressida",
+                        "characterId": "Cassandra_Tro",
+                        "characterName": "Cassandra"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "Q210372",
+                    "count": 2,
+                    "plays": [
+                      {
+                        "id": "ita000055",
+                        "uri": "https://dracor.org/id/ita000055",
+                        "authors": ["Lorenzo Da Ponte"],
+                        "title": "Don Giovanni",
+                        "characterId": "don_giovanni",
+                        "characterName": "Don Giovanni"
+                      },
+                      {
+                        "id": "rus000021",
+                        "uri": "https://dracor.org/id/rus000021",
+                        "authors": ["Александр Сергеевич Пушкин"],
+                        "title": "Каменный гость",
+                        "characterId": "don_guan",
+                        "characterName": "Дон Гуан"
+                      }
+                    ]
+                  }
+                ]
 
   /character/{id}:
     get:
@@ -1004,7 +1075,7 @@ paths:
           required: true
           schema:
             type: string
-          example: Q131412
+          example: Q131351
       responses:
         '200':
           description: List of plays.
@@ -1014,6 +1085,73 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/PlayWithWikidataCharacter'
+              example: |
+                [
+                  {
+                    "id": "ita000001",
+                    "uri": "https://dracor.org/id/ita000001",
+                    "authors": ["Luigi Alamanni"],
+                    "title": "Tragedia di Antigone",
+                    "characterId": "antigone",
+                    "characterName": "Antigone"
+                  },
+                  {
+                    "id": "ita000014",
+                    "uri": "https://dracor.org/id/ita000014",
+                    "authors": ["Vittorio Alfieri"],
+                    "title": "Polinice",
+                    "characterId": "antigone",
+                    "characterName": "Antigone"
+                  },
+                  {
+                    "id": "rom000015",
+                    "uri": "https://dracor.org/id/rom000015",
+                    "authors": ["Seneca"],
+                    "title": "Phoenissae",
+                    "characterId": "antigona",
+                    "characterName": "Antigona"
+                  },
+                  {
+                    "id": "rus000114",
+                    "uri": "https://dracor.org/id/rus000114",
+                    "authors": ["Василий Васильевич Капнист"],
+                    "title": "Антигона",
+                    "characterId": "antigona",
+                    "characterName": "Антигона"
+                  },
+                  {
+                    "id": "greek000005",
+                    "uri": "https://dracor.org/id/greek000005",
+                    "authors": ["Αἰσχύλος"],
+                    "title": "Ἑπτὰ ἐπὶ Θήβας",
+                    "characterId": "antigone",
+                    "characterName": "Ἀντιγόνη"
+                  },
+                  {
+                    "id": "greek000030",
+                    "uri": "https://dracor.org/id/greek000030",
+                    "authors": ["Εὐριπίδης"],
+                    "title": "Φοίνισσαι",
+                    "characterId": "antigone",
+                    "characterName": "Ἀντιγόνη"
+                  },
+                  {
+                    "id": "greek000025",
+                    "uri": "https://dracor.org/id/greek000025",
+                    "authors": ["Σοφοκλῆς"],
+                    "title": "Ἀντιγόνη",
+                    "characterId": "antigone",
+                    "characterName": "Ἀντιγόνη"
+                  },
+                  {
+                    "id": "greek000036",
+                    "uri": "https://dracor.org/id/greek000036",
+                    "authors": ["Σοφοκλῆς"],
+                    "title": "Οἰδίπους ἐπὶ Κολωνῷ",
+                    "characterId": "antigone",
+                    "characterName": "Ἀντιγόνη"
+                  }
+                ]
         '400':
           description: Invalid character ID.
         '404':

--- a/api.yaml
+++ b/api.yaml
@@ -977,7 +977,7 @@ paths:
         releases. Do not rely on this endpoint for stable integrations.**
 
         Returns all characters that have an assigned Wikidata ID, grouped by
-        Q-number and sorted by the number of plays they appear in (descending).
+        QID and sorted by the number of plays they appear in (descending).
         Wikidata IDs are read from `<idno type="wikidata">` on `person` and
         `personGrp` elements.
       operationId: get-all-characters-with-wikidata-id
@@ -985,7 +985,7 @@ paths:
       x-dracor-experimental: true
       responses:
         '200':
-          description: List of characters grouped by Wikidata Q-number.
+          description: List of characters grouped by Wikidata ID.
           content:
             application/json:
               schema:
@@ -2420,7 +2420,7 @@ components:
       properties:
         id:
           type: string
-          description: Wikidata Q-number (e.g. Q130890)
+          description: Wikidata ID (e.g. Q130890)
           pattern: '^Q[1-9][0-9]*$'
         count:
           type: integer

--- a/api.yaml
+++ b/api.yaml
@@ -971,14 +971,18 @@ paths:
 
   /characters:
     get:
-      summary: List all characters with a Wikidata ID across all corpora
-      description: >-
+      summary: "[Experimental] List all characters with a Wikidata ID across all corpora"
+      description: |
+        **⚠ Experimental — response shape and semantics may change in future
+        releases. Do not rely on this endpoint for stable integrations.**
+
         Returns all characters that have an assigned Wikidata ID, grouped by
         Q-number and sorted by the number of plays they appear in (descending).
         Wikidata IDs are read from `<idno type="wikidata">` on `person` and
-        `personGrp` elements, with a deprecated fallback to `@ana` URIs.
+        `personGrp` elements.
       operationId: get-all-characters-with-wikidata-id
       tags: [public]
+      x-dracor-experimental: true
       responses:
         '200':
           description: List of characters grouped by Wikidata Q-number.

--- a/api.yaml
+++ b/api.yaml
@@ -969,6 +969,26 @@ paths:
         '404':
           description: No play found by this ID
 
+  /characters:
+    get:
+      summary: List all characters with a Wikidata ID across all corpora
+      description: >-
+        Returns all characters that have an assigned Wikidata ID, grouped by
+        Q-number and sorted by the number of plays they appear in (descending).
+        Wikidata IDs are read from `<idno type="wikidata">` on `person` and
+        `personGrp` elements, with a deprecated fallback to `@ana` URIs.
+      operationId: get-all-characters-with-wikidata-id
+      tags: [public]
+      responses:
+        '200':
+          description: List of characters grouped by Wikidata Q-number.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WikidataCharacterWithPlays'
+
   /character/{id}:
     get:
       summary: List plays having a character identified by Wikidata ID
@@ -2390,6 +2410,25 @@ components:
         - sex
         - roles
         - text
+    WikidataCharacterWithPlays:
+      # see dutil:get-all-characters-with-wikidata-id
+      type: object
+      properties:
+        id:
+          type: string
+          description: Wikidata Q-number (e.g. Q130890)
+          pattern: '^Q[1-9][0-9]*$'
+        count:
+          type: integer
+          description: Number of plays containing this character
+        plays:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlayWithWikidataCharacter'
+      required:
+        - id
+        - count
+        - plays
     PlayWithWikidataCharacter:
       # see dutil:get-plays-with-character
       type: object
@@ -2405,6 +2444,8 @@ components:
           type: array
           items:
             type: string
+        characterId:
+          type: string
         characterName:
           type: string
       required:
@@ -2412,6 +2453,7 @@ components:
         - uri
         - title
         - authors
+        - characterId
         - characterName
     DtsEntrypoint:
       # see ddts:entry-point

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -1464,6 +1464,22 @@ function api:stage-directions-with-speakers($corpusname, $playname) {
 };
 
 (:~
+ : List all characters with a Wikidata ID across all corpora, grouped by
+ : Q-number and sorted by play count descending.
+ :
+ : @result Array of JSON objects
+ :)
+declare
+  %rest:GET
+  %rest:path("/v1/characters")
+  %rest:produces("application/json")
+  %output:media-type("application/json")
+  %output:method("json")
+function api:get-all-characters-with-wikidata-id() {
+  dutil:get-all-characters-with-wikidata-id()
+};
+
+(:~
  : List plays with character identified by Wikidata ID
  :
  : @param $id Wikidata ID

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -1465,7 +1465,7 @@ function api:stage-directions-with-speakers($corpusname, $playname) {
 
 (:~
  : List all characters with a Wikidata ID across all corpora, grouped by
- : Q-number and sorted by play count descending.
+ : QID and sorted by play count descending.
  :
  : @result Array of JSON objects
  :)

--- a/modules/util.xqm
+++ b/modules/util.xqm
@@ -1382,7 +1382,7 @@ declare function dutil:get-plays-with-character ($id as xs:string) {
 
 (:~
  : Get all characters with a Wikidata ID across all corpora, grouped by
- : Q-number, sorted by play count descending.
+ : QID, sorted by play count descending.
  :
  : Reads QIDs from <idno type="wikidata"> on tei:person and tei:personGrp,
  : with a deprecated fallback to @ana URIs (see dutil:get-character-wikidata-id).

--- a/modules/util.xqm
+++ b/modules/util.xqm
@@ -1375,7 +1375,7 @@ declare function dutil:get-plays-with-character ($id as xs:string) {
       "title": $titles?main,
       "authors": array { for $author in $authors return $author?fullname },
       "characterId": $character/@xml:id/string(),
-      "characterName": normalize-space($character/tei:persName[1])
+      "characterName": normalize-space($character/(tei:persName|tei:name)[1])
     }
   }
 };
@@ -1407,7 +1407,7 @@ declare function dutil:get-all-characters-with-wikidata-id () {
         "title": $titles?main,
         "authors": $author-names,
         "characterId": $c/@xml:id/string(),
-        "characterName": normalize-space($c/tei:persName[1])
+        "characterName": normalize-space($c/(tei:persName|tei:name)[1])
       }
     }
   return array {

--- a/modules/util.xqm
+++ b/modules/util.xqm
@@ -1374,7 +1374,57 @@ declare function dutil:get-plays-with-character ($id as xs:string) {
       "uri": "https://dracor.org/id/" || $play-id,
       "title": $titles?main,
       "authors": array { for $author in $authors return $author?fullname },
+      "characterId": $character/@xml:id/string(),
       "characterName": normalize-space($character/tei:persName[1])
+    }
+  }
+};
+
+(:~
+ : Get all characters with a Wikidata ID across all corpora, grouped by
+ : Q-number, sorted by play count descending.
+ :
+ : Reads QIDs from <idno type="wikidata"> on tei:person and tei:personGrp,
+ : with a deprecated fallback to @ana URIs (see dutil:get-character-wikidata-id).
+ :)
+declare function dutil:get-all-characters-with-wikidata-id () {
+  let $tuples :=
+    for $tei in collection($config:corpora-root)/tei:TEI
+    let $play-id := dutil:get-dracor-id($tei)
+    let $titles := dutil:get-titles($tei)
+    let $author-names := array {
+      for $a in dutil:get-authors($tei) return $a?fullname
+    }
+    for $c in $tei//tei:particDesc//(tei:person|tei:personGrp)
+    let $q-id := dutil:get-character-wikidata-id($c)
+    where $q-id
+    return map {
+      "q": $q-id,
+      "pid": $play-id,
+      "play": map {
+        "id": $play-id,
+        "uri": "https://dracor.org/id/" || $play-id,
+        "title": $titles?main,
+        "authors": $author-names,
+        "characterId": $c/@xml:id/string(),
+        "characterName": normalize-space($c/tei:persName[1])
+      }
+    }
+  return array {
+    for $t in $tuples
+    let $q := $t?q
+    group by $q
+    let $plays :=
+      for $u in $t
+      let $pid := $u?pid
+      group by $pid
+      return ($u[1])?play
+    let $count := count($plays)
+    order by $count descending, $q ascending
+    return map {
+      "id": $q,
+      "count": $count,
+      "plays": array { $plays }
     }
   }
 };


### PR DESCRIPTION
Resolves #161. The endpoint returns all characters that have an assigned Wikidata ID across all corpora, grouped by QID and sorted by play count descending, to make ranking easy.

Each entry has:
- id: Wikidata ID
- count: number of plays containing the character
- plays: array of PlayWithWikidataCharacter (id, uri, title, authors, characterName) — same shape as /character/{id}

Reuses dutil:get-character-wikidata-id (idno-first, `@ana` fallback) and dutil:get-plays-with-character, so both the canonical <idno type="wikidata"> encoding and the deprecated `@ana` form are covered without duplication.

Note that I have named the endpoint `/characters` instead of `/character/all` for several reasons. The plural is more in line with other endpoints, e.g. `/corpora` or `.../plays/...`. `/character/all` would have been an odd mixture of singular and plural. A special case path segment `all` that is not a Wikidata ID, while not unusual, feels a bit ugly and unnecessary in this case.