### PR TITLE
Fix DTS endpoints to pass schemathesis tests

### DIFF
--- a/.github/workflows/schemathesis.yml
+++ b/.github/workflows/schemathesis.yml
@@ -36,7 +36,7 @@ jobs:
           base-url: http://localhost:8081/exist/restxq/v1/
           authorization: 'Basic YWRtaW46'
           max-examples: 100
-          args: "--include-method GET --exclude-tag DTS --exclude-operation-id wikidata-author-info --mode positive --request-timeout 30"
+          args: "--include-method GET --exclude-operation-id wikidata-author-info --mode positive --request-timeout 30"
 
       - name: Stop the docker-compose stack
         run: docker compose down

--- a/api.yaml
+++ b/api.yaml
@@ -1208,7 +1208,7 @@ paths:
         - name: id
           in: query
           required: false
-          description: Identifier for a collection or document. Preferably the full URI of a corpus or a play, but shorter DraCor IDs are also supported.
+          description: Identifier for a collection. Preferably the full URI of a corpus, but shorter DraCor corpus IDs are also supported.
           schema:
             type: string
           examples:
@@ -1290,6 +1290,7 @@ paths:
           description: The unique identifier for the Resource whose tree or subtree must be returned. Should be the full URI of a play (recommended) or the DraCor ID.
           schema:
             type: string
+            minLength: 1
           example: https://dracor.org/id/ger000088
         - name: ref
           in: query
@@ -1358,6 +1359,7 @@ paths:
           description: The unique identifier for the Resource whose tree or subtree must be returned. Should be the full URI of a play (recommended) or the DraCor ID.
           schema:
             type: string
+            minLength: 1
           example: https://dracor.org/id/ger000088
         - name: ref
           in: query

--- a/modules/dts.xqm
+++ b/modules/dts.xqm
@@ -191,6 +191,16 @@ declare
   %output:method("json")
 function ddts:collections($id as xs:string*, $page as xs:string*, $nav as xs:string*)
 as item()+ {
+  let $id := $id[1]
+  let $page := $page[1]
+  let $nav := $nav[1]
+  return
+  if ($nav and $nav != "parents") then
+    (
+      <rest:response><http:response status="400"/></rest:response>,
+      "The value '" || $nav || "' of the parameter 'nav' is not allowed. Use the single allowed value 'parents' if you want to request the parent collection."
+    )
+  else
   (: check, if param $id is set -- request a certain collection :)
   if ( $id ) then
 
@@ -349,9 +359,9 @@ as item()+ {
     (: test: http://localhost:8088/api/v1/dts/collection?id=http://localhost:8088/id/ger12345 :)
         (
             <rest:response>
-                <http:response status="400"/>
+                <http:response status="404"/>
             </rest:response>,
-                    "The value '" || $id || "' of the parameter 'id' is not in a valid format: Either provide the id or URI of a corpus or play."
+                    "The value '" || $id || "' of the parameter 'id' does not identify a known collection. Provide the name or URI of a corpus."
         )
 
   else
@@ -652,28 +662,35 @@ as item()+
 
  :)
 declare function local:child-readable-collection-with-parent-by-id($id as xs:string)
-as map()
+as item()+
 {
-    let $self := local:child-readable-collection-by-id($id)
-
-    (: get parent collection and remove the members :)
-
-    (: TODO: maybe use a dutil:function instead; this is very custom; not sure how this will
-    work when something is changed in the general API code
-     :)
     let $file-db-path := util:collection-name(collection($config:corpora-root)/tei:TEI[@xml:id eq $id])
     let $corpusname := tokenize(replace($file-db-path, "/db/dracor/corpora/",""),"/")[1]
-
-    (: get the parent by the function to generate a collection :)
-    let $parent := local:corpus-to-collection($corpusname)
-
-    (: remove "members" and "@context" :)
-    let $parent-without-members := map:remove($parent,"member")
-    let $parent-without-context := map:remove($parent-without-members, "@context")
-    let $members := map {"member" : array { $parent-without-context }}
-
     return
-        map:merge(($self, $members))
+        if (not($corpusname)) then
+            (
+                <rest:response><http:response status="404"/></rest:response>,
+                "Resource '" || $id || "' does not exist!"
+            )
+        else
+            let $self := local:child-readable-collection-by-id($id)
+
+            (: get parent collection and remove the members :)
+
+            (: TODO: maybe use a dutil:function instead; this is very custom; not sure how this will
+            work when something is changed in the general API code
+             :)
+
+            (: get the parent by the function to generate a collection :)
+            let $parent := local:corpus-to-collection($corpusname)
+
+            (: remove "members" and "@context" :)
+            let $parent-without-members := map:remove($parent,"member")
+            let $parent-without-context := map:remove($parent-without-members, "@context")
+            let $members := map {"member" : array { $parent-without-context }}
+
+            return
+                map:merge(($self, $members))
 };
 
 
@@ -894,7 +911,7 @@ as item() {
  : $tree
  : $mediaType
  :
- : Params used in POST, PUT, DELETE requests are not availiable
+ : Params used in POST, PUT, DELETE requests are not available
 
  :)
 
@@ -925,23 +942,22 @@ declare
   %output:media-type("application/xml")
   %output:method("xml")
 function ddts:document($resource, $ref, $start, $end, $tree, $media-type) {
+  let $resource := $resource[1]
+  let $ref := $ref[1]
+  (: ref takes precedence: if ref is set, start and end are ignored :)
+  let $start := if ($ref) then () else $start[1]
+  let $end := if ($ref) then () else $end[1]
+  (: start and end must both be present for a range; if only one is given, ignore both :)
+  let $start := if ($start and $end) then $start else ()
+  let $end := if ($start and $end) then $end else ()
+  let $media-type := $media-type[1]
+  return
 
     (: TODO: to properly implement a possibility to request a document or fragment in a different media type
     we would need to set the serialization parameters rest:produces, output: ... dynamically :)
     (: check, if valid request :)
 
-    (: In GET requests one may either provide a ref parameter or a pair of start and end parameters. A request cannot combine ref with the other two. If, say, a ref and a start are both provided this should cause the request to fail. :)
-    if ( $ref and ( $start or $end ) ) then
-        (
-        <rest:response>
-            <http:response status="400"/>
-        </rest:response>,
-        <error statusCode="400" xmlns="https://w3id.org/dts/api#">
-            <title>Bad Request</title>
-            <description>GET requests may either have a 'ref' parameter or a pair of 'start' and 'end' parameters. A request cannot combine 'ref' with the other two.</description>
-        </error>
-        )
-    else if ( ($start and not($end) ) or ( $end and not($start) ) ) then
+    if ( ($start and not($end) ) or ( $end and not($start) ) ) then
         (: requesting a range, should check, if start and end is present :)
         (
         <rest:response>
@@ -1405,7 +1421,7 @@ declare function local:collections-self-describe() {
         </rest:response>,
         <error statusCode="400" xmlns="https://w3id.org/dts/api#">
             <title>Bad Request</title>
-            <description>Should at least use the required parameter 'id'. Automatic self description is not availiable.</description>
+            <description>Should at least use the required parameter 'id'. Automatic self description is not available.</description>
         </error>
         )
 };
@@ -1788,6 +1804,17 @@ declare function local:link-header-of-fragment($tei as element(tei:TEI), $ref as
   %output:media-type("application/ld+json")
   %output:method("json")
  function ddts:navigation($resource, $ref, $start, $end, $level, $down) {
+  let $resource := $resource[1]
+  let $ref := $ref[1]
+  (: ref takes precedence: if ref is set, start and end are ignored :)
+  let $start := if ($ref) then () else $start[1]
+  let $end := if ($ref) then () else $end[1]
+  (: start and end must both be present for a range; if only one is given, ignore both :)
+  let $start := if ($start and $end) then $start else ()
+  let $end := if ($start and $end) then $end else ()
+  (: default to top-level navigation when no navigation parameter is specified :)
+  let $down := if ($down[1]) then $down[1] else if (not($ref) and not($start)) then "1" else ()
+  return
     (: parameter $id is mandatory :)
     if ( not($resource) ) then
         (
@@ -1795,14 +1822,6 @@ declare function local:link-header-of-fragment($tei as element(tei:TEI), $ref as
             <http:response status="400"/>
         </rest:response>,
         "Mandatory parameter 'resource' is missing."
-        )
-    (: both ref and either start or end is specified should return an error :)
-    else if ( $ref and ($start or $end) ) then
-        (
-        <rest:response>
-            <http:response status="400"/>
-        </rest:response>,
-        "Bad Request: Use of both parameters 'ref' and 'start' or 'end' is not allowed."
         )
     (: should not use start without end or vice versa :)
     else if ( ($start and not($end)) or ($end and not($start)) ) then
@@ -2521,7 +2540,7 @@ declare function local:snippet($tei-fragment as element()) {
 
         (: end of level2 :)
      else
-        (: this level is not implemented/not availiable :)
+        (: this level is not implemented/not available :)
         (
             <rest:response>
                 <http:response status="400"/>

--- a/test/schemathesis.sh
+++ b/test/schemathesis.sh
@@ -2,7 +2,6 @@
 
 schemathesis run http://localhost:8081/exist/restxq/v1/openapi.yaml \
   --include-method GET \
-  --exclude-tag DTS \
   --exclude-operation-id wikidata-author-info \
   --mode positive \
   --max-examples 50 \


### PR DESCRIPTION
Stacked on top of #370. This branch restores the DTS-specific fixes that were removed from #370 while it was refocused on the schemathesis upgrade alone.

## Summary

- `modules/dts.xqm` — server-side leniency fixes for `/dts/collection`, `/dts/document`, and `/dts/navigation` so schema-compliant requests are no longer rejected with 400/500:
  - `ddts:collections` validates the `nav` parameter (400 for values other  than `parents`).
  - `local:corpus-or-play-collection-by-id` returns 404 instead of 400 when  the id does not identify a known collection.
  - `local:child-readable-collection-with-parent-by-id` returns 404 when the play id is unknown, replacing the previous 500 cardinality error.
  - `ddts:document` and `ddts:navigation` treat `ref` as taking precedence over `start`/`end`, silently ignore incomplete `start`/`end` ranges, and default navigation to `down=1` when no navigation parameter is provided.
- `api.yaml` — `minLength: 1` on the `resource` parameter of `/dts/navigation` and `/dts/document`; tightened description of the `/dts/collection` `id` parameter.

These fixes are conservative leniency patches meant to keep the current implementation passing the schemathesis suite until we update the implementation to comply with DTS version 1.0. They should be reviewed as an interim measure.
